### PR TITLE
Allow all minor updates of Rails 5.0.

### DIFF
--- a/swagger_rails.gemspec
+++ b/swagger_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,bower_components/swagger-ui/dist,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency 'rack'
-  s.add_dependency "rails", ">= 3.1", "<= 5"
+  s.add_dependency "rails", ">= 3.1", "< 5.1"
 
   s.add_development_dependency "rspec-rails", "~> 3.0"
 end


### PR DESCRIPTION
Rails 5.0.0.1 was released on Aug 11, 2016.
http://weblog.rubyonrails.org/2016/8/11/Rails-5-0-0-1-4-2-7-2-and-3-2-22-3-have-been-released/
