### PR TITLE
Keep resulting swagger.json consistent

### DIFF
--- a/lib/tasks/swagger_rails_tasks.rake
+++ b/lib/tasks/swagger_rails_tasks.rake
@@ -9,6 +9,6 @@ if defined?(RSpec)
   desc 'Generate Swagger JSON files from integration specs'
   RSpec::Core::RakeTask.new('swaggerize') do |t|
     t.pattern = 'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
-    t.rspec_opts = [ '--format SwaggerRails::RSpec::Formatter', '--dry-run' ]
+    t.rspec_opts = [ '--format SwaggerRails::RSpec::Formatter', '--dry-run', '--order defined' ]
   end
 end


### PR DESCRIPTION
Keep the execution order of the specs so that the resulting swagger.json will be consistent.
