### PR TITLE
Quote the name in the Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ __NOTE__: It's early days so please be gentle when reporting issues :) As author
 1. Add this line to your applications _Gemfile_:
 
     ```ruby
-    gem swagger_rails
+    gem 'swagger_rails'
     ```
 
 2. Run the install generator


### PR DESCRIPTION
For the folks who cut and paste from the readme we should make the gem name a string, otherwise I think it'll be interpreted as a method name.
