### PR TITLE
Try to ensure we generate valid swagger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.2
+cache: bundler
+install: bundle install && cd spec/dummy && bundle exec rake db:setup && cd -
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 swagger_rails
 =========
 
+[![Build Status](https://travis-ci.org/domaindrivendev/swagger_rails.svg)](https://travis-ci.org/domaindrivendev/swagger_rails)
+
 Generate API documentation, including a slick discovery UI and playground, directly from your rspec integration specs. Use the provided DSL to describe and test API operations in your spec files. Then, you can easily generate corresponding swagger.json files and serve them up with an embedded version of [swagger-ui](https://github.com/swagger-api/swagger-ui). Best of all, it requires minimal coding and maintenance, allowing you to focus on building an awesome API!
 
 And that's not all ...

--- a/lib/swagger_rails/rspec/api_metadata.rb
+++ b/lib/swagger_rails/rspec/api_metadata.rb
@@ -35,7 +35,7 @@ module SwaggerRails::RSpec
         produces: @metadata[:produces],
         parameters: @metadata[:parameters],
         responses: { @metadata[:response_code] => @metadata[:response] }
-      }
+      }.reject{ |_,v| v.nil? }
     end
 
     def find_root_of(node)

--- a/lib/swagger_rails/rspec/dsl.rb
+++ b/lib/swagger_rails/rspec/dsl.rb
@@ -43,10 +43,14 @@ module SwaggerRails
       # Or references:
       #    parameter ref: '#/parameters/Pet'
       def parameter(name, attributes={})
-        metadata[:parameters] << if name.respond_to?(:has_key?)
-          { '$ref': name.delete(:ref) || name.delete('ref') }
+        if name.respond_to?(:has_key?)
+          metadata[:parameters] << { '$ref': name.delete(:ref) || name.delete('ref') }
         else
-          { name: name.to_s }.merge(attributes)
+          attributes.symbolize_keys!
+          if attributes[:in] == 'path' || attributes[:in] == :path
+            attributes[:required] = true
+          end
+          metadata[:parameters] << { name: name.to_s }.merge(attributes)
         end
       end
 

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -26,7 +26,7 @@ module SwaggerRails
 
         parameter
           .slice(:name, :in)
-          .merge(value: test.send(parameter[:name].to_s.underscore))
+          .merge(value: test.send(parameter[:name].to_s))
       end
     end
 

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -11,7 +11,8 @@ module SwaggerRails
       path = build_path(metadata[:path_template], params_data)
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
-      test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+
+      test.send(metadata[:http_verb], path, body_or_params, headers)
     end
 
     def assert_response!(test, metadata)

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -12,7 +12,11 @@ module SwaggerRails
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
 
-      test.send(metadata[:http_verb], path, body_or_params, headers)
+      if Rails::VERSION::MAJOR >= 5
+        test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+      else
+        test.send(metadata[:http_verb], path, body_or_params, headers)
+      end
     end
 
     def assert_response!(test, metadata)

--- a/spec/dummy/spec/integration/blogs_spec.rb
+++ b/spec/dummy/spec/integration/blogs_spec.rb
@@ -40,7 +40,7 @@ describe 'Blogs API', swagger_doc: 'v1/swagger.json' do
     get 'retrieves a specific blog' do
       operation_description 'For the id passed in the path, it searches and retrieves a blog against that id. If blog not found it returns a 404'
       produces 'application/json'
-      parameter :id, :in => :path, :type => :string
+      parameter :id, :in => :path, :type => :string, :required => true
 
       response '200', 'blog found' do
         let(:blog) { Blog.create(title: 'foo', content: 'bar') }

--- a/spec/dummy/swagger/v1/swagger.json
+++ b/spec/dummy/swagger/v1/swagger.json
@@ -49,8 +49,6 @@
           "Blogs API"
         ],
         "summary": "searches existing blogs",
-        "description": null,
-        "consumes": null,
         "produces": [
           "application/json"
         ],
@@ -71,7 +69,6 @@
         ],
         "summary": "retrieves a specific blog",
         "description": "For the id passed in the path, it searches and retrieves a blog against that id. If blog not found it returns a 404",
-        "consumes": null,
         "produces": [
           "application/json"
         ],
@@ -79,7 +76,8 @@
           {
             "name": "id",
             "in": "path",
-            "type": "string"
+            "type": "string",
+            "required": true
           }
         ],
         "responses": {

--- a/spec/swagger_rails/rspec/api_metadata_spec.rb
+++ b/spec/swagger_rails/rspec/api_metadata_spec.rb
@@ -121,5 +121,22 @@ RSpec.describe ::SwaggerRails::RSpec::APIMetadata do
                                                                                         :parameters => [],
                                                                                         :responses => { '200' => { :description => '(OK) Site up and running' } } } } } })
     end
+
+    it 'filters out nil values' do
+      request_metadata = SwaggerRails::RSpec::APIMetadata.new({
+        path_template: '/foo/{bar}',
+        http_verb: :get,
+        summary: nil,
+        operation_description: nil,
+        consumes: nil,
+        produces: nil,
+        parameters: [],
+        response_code: 200,
+        response: { description: nil }
+      })
+      expect(request_metadata.swagger_data).to eq({ paths: { "/foo/{bar}" => { get: { tags: [nil],
+                                                                                      parameters: [],
+                                                                                      responses: { 200 => {:description => nil} } } } } })
+    end
   end
 end

--- a/spec/swagger_rails/rspec/dsl_spec.rb
+++ b/spec/swagger_rails/rspec/dsl_spec.rb
@@ -1,0 +1,28 @@
+require 'swagger_rails/rspec/dsl'
+
+RSpec.describe ::SwaggerRails::RSpec::DSL do
+  let(:mock_class) do
+    Class.new do
+      include ::SwaggerRails::RSpec::DSL
+
+      attr_reader :metadata
+
+      def initialize
+        @metadata = {}
+      end
+    end
+  end
+
+  subject { mock_class.new }
+
+  describe "#parameter" do
+    it "sets required: true for path parameters" do
+      subject.metadata[:parameters] = []
+
+      subject.parameter(:param_name, in: :path, type: :string)
+
+      expect(subject.metadata[:parameters].count).to eq(1)
+      expect(subject.metadata[:parameters].first).to eq({name: "param_name", in: :path, type: :string, required: true})
+    end
+  end
+end

--- a/spec/swagger_rails/test_visitor_spec.rb
+++ b/spec/swagger_rails/test_visitor_spec.rb
@@ -78,7 +78,7 @@ module SwaggerRails
 
       context 'given header parameters' do
         let(:metadata) do
-          allow(test).to receive(:date).and_return('2000-01-01')
+          allow(test).to receive(:Date).and_return('2000-01-01')
           return {
             path_template: '/resource',
             http_verb: :get,

--- a/spec/swagger_rails/test_visitor_spec.rb
+++ b/spec/swagger_rails/test_visitor_spec.rb
@@ -36,7 +36,7 @@ module SwaggerRails
         end
 
         it 'builds the path from values on the test object' do
-          expect(test).to have_received(:get).with('/resource/1', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/resource/1', {}, {})
         end
       end
 
@@ -53,10 +53,9 @@ module SwaggerRails
 
         it 'builds a body from value on the test object' do
           expect(test).to have_received(:post).with(
-            '/resource', {
-              params: "{\"foo\":\"bar\"}",
-              headers: { 'CONTENT_TYPE' => 'application/json' }
-            }
+            '/resource',
+            "{\"foo\":\"bar\"}",
+            { 'CONTENT_TYPE' => 'application/json' }
           )
         end
       end
@@ -72,7 +71,7 @@ module SwaggerRails
         end
 
         it 'builds query params from values on the test object' do
-          expect(test).to have_received(:get).with('/resource', { params: { 'type' => 'foo' }, headers: {} })
+          expect(test).to have_received(:get).with('/resource', { 'type' => 'foo' }, {})
         end
       end
 
@@ -89,10 +88,9 @@ module SwaggerRails
 
         it 'builds request headers from values on the test object' do
           expect(test).to have_received(:get).with(
-            '/resource', {
-              params: {},
-              headers: { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
-            }
+            '/resource',
+            {},
+            { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
           )
         end
       end
@@ -108,7 +106,7 @@ module SwaggerRails
         end
 
         it 'prepends the basePath to the request path' do
-          expect(test).to have_received(:get).with('/api/resource', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/api/resource', {}, {})
         end
       end
     end


### PR DESCRIPTION
Swagger considers null values the `description`, `consumes`, `produces`, etc fields
as invalid. If I take what is currently in `spec/dummy/swagger/v1/swagger.json` and drop it in the [swagger editor](http://editor.swagger.io/) you'll get validation errors for the following:
- `description: null` => `Expected type array but found type null`
- `consumes: null` => `Expected type array but found type null`

These are easily fixed by rejecting the nil values.
