### PR TITLE
Don't call underscore on param names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.2
+cache: bundler
+install: bundle install && cd spec/dummy && bundle exec rake db:setup && cd -
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 swagger_rails
 =========
 
+[![Build Status](https://travis-ci.org/domaindrivendev/swagger_rails.svg)](https://travis-ci.org/domaindrivendev/swagger_rails)
+
 Generate API documentation, including a slick discovery UI and playground, directly from your rspec integration specs. Use the provided DSL to describe and test API operations in your spec files. Then, you can easily generate corresponding swagger.json files and serve them up with an embedded version of [swagger-ui](https://github.com/swagger-api/swagger-ui). Best of all, it requires minimal coding and maintenance, allowing you to focus on building an awesome API!
 
 And that's not all ...

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -11,7 +11,8 @@ module SwaggerRails
       path = build_path(metadata[:path_template], params_data)
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
-      test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+
+      test.send(metadata[:http_verb], path, body_or_params, headers)
     end
 
     def assert_response!(test, metadata)

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -31,7 +31,7 @@ module SwaggerRails
 
         parameter
           .slice(:name, :in)
-          .merge(value: test.send(parameter[:name].to_s.underscore))
+          .merge(value: test.send(parameter[:name].to_s))
       end
     end
 

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -12,7 +12,11 @@ module SwaggerRails
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
 
-      test.send(metadata[:http_verb], path, body_or_params, headers)
+      if Rails::VERSION::MAJOR >= 5
+        test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+      else
+        test.send(metadata[:http_verb], path, body_or_params, headers)
+      end
     end
 
     def assert_response!(test, metadata)

--- a/spec/swagger_rails/test_visitor_spec.rb
+++ b/spec/swagger_rails/test_visitor_spec.rb
@@ -77,7 +77,7 @@ module SwaggerRails
 
       context 'given header parameters' do
         let(:metadata) do
-          allow(test).to receive(:date).and_return('2000-01-01')
+          allow(test).to receive(:Date).and_return('2000-01-01')
           return {
             path_template: '/resource',
             http_verb: :get,

--- a/spec/swagger_rails/test_visitor_spec.rb
+++ b/spec/swagger_rails/test_visitor_spec.rb
@@ -36,7 +36,7 @@ module SwaggerRails
         end
 
         it 'builds the path from values on the test object' do
-          expect(test).to have_received(:get).with('/resource/1', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/resource/1', {}, {})
         end
       end
 
@@ -53,10 +53,9 @@ module SwaggerRails
 
         it 'builds a body from value on the test object' do
           expect(test).to have_received(:post).with(
-            '/resource', {
-              params: "{\"foo\":\"bar\"}",
-              headers: { 'CONTENT_TYPE' => 'application/json' }
-            }
+            '/resource',
+            "{\"foo\":\"bar\"}",
+            { 'CONTENT_TYPE' => 'application/json' }
           )
         end
       end
@@ -72,7 +71,7 @@ module SwaggerRails
         end
 
         it 'builds query params from values on the test object' do
-          expect(test).to have_received(:get).with('/resource', { params: { 'type' => 'foo' }, headers: {} })
+          expect(test).to have_received(:get).with('/resource', { 'type' => 'foo' }, {})
         end
       end
 
@@ -89,10 +88,9 @@ module SwaggerRails
 
         it 'builds request headers from values on the test object' do
           expect(test).to have_received(:get).with(
-            '/resource', {
-              params: {},
-              headers: { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
-            }
+            '/resource',
+            {},
+            { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
           )
         end
       end
@@ -108,7 +106,7 @@ module SwaggerRails
         end
 
         it 'prepends the basePath to the request path' do
-          expect(test).to have_received(:get).with('/api/resource', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/api/resource', {}, {})
         end
       end
     end


### PR DESCRIPTION
I was trying to document some parameters that come into an OAuth callback:

``` ruby
      parameter :realmId, in: :query, type: :string, required: true
```

and defined the value with:

``` ruby
      let(:realmId) { connection.qb_company_id }
```

but was getting this really confusing error:

```
     Failure/Error: super

     NoMethodError:
       undefined method `realm_id' for #<RSpec::ExampleGroups::QBOConnections::SitesSiteIdQboConnectionFinishOauth::Put::Invalid:0x007fe69de75f78>
       Did you mean?  realmId
     # /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:967:in `method_missing'
     # /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.2/lib/rspec/core/example_group.rb:747:in `method_missing'
     # /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.0/lib/action_dispatch/testing/assertions/routing.rb:172:in `method_missing'
     # /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.0/lib/action_dispatch/testing/integration.rb:546:in `method_missing'
     # /Users/andrew/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/swagger_rails-5003b7ccd9ff/lib/swagger_rails/test_visitor.rb:33:in `block in params_data_for'
```

Eventually I realized that this was calling underscore and I should be doing `let(:realm_id)` but that just seems unnecessarily complex. It seems much more obvious to just have the `let(:fooBar)` and `parameter :fooBar` use the same names.

No specs so let me know what you'd like to see in that regard.
