### PR TITLE
Capture request output as examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.2
+cache: bundler
+install: bundle install && cd spec/dummy && bundle exec rake db:setup && cd -
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 swagger_rails
 =========
 
+[![Build Status](https://travis-ci.org/domaindrivendev/swagger_rails.svg)](https://travis-ci.org/domaindrivendev/swagger_rails)
+
 Generate API documentation, including a slick discovery UI and playground, directly from your rspec integration specs. Use the provided DSL to describe and test API operations in your spec files. Then, you can easily generate corresponding swagger.json files and serve them up with an embedded version of [swagger-ui](https://github.com/swagger-api/swagger-ui). Best of all, it requires minimal coding and maintenance, allowing you to focus on building an awesome API!
 
 And that's not all ...

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -17,6 +17,10 @@ module SwaggerRails
       else
         test.send(metadata[:http_verb], path, body_or_params, headers)
       end
+
+      # Store a copy of the results so we can use it as an example
+      metadata[:response_mime_type] = test.response.headers['Content-Type'].split(';').first
+      metadata[:response_body] = test.response.body
     end
 
     def assert_response!(test, metadata)

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -11,7 +11,8 @@ module SwaggerRails
       path = build_path(metadata[:path_template], params_data)
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
-      test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+
+      test.send(metadata[:http_verb], path, body_or_params, headers)
     end
 
     def assert_response!(test, metadata)

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -12,7 +12,11 @@ module SwaggerRails
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
 
-      test.send(metadata[:http_verb], path, body_or_params, headers)
+      if Rails::VERSION::MAJOR >= 5
+        test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+      else
+        test.send(metadata[:http_verb], path, body_or_params, headers)
+      end
     end
 
     def assert_response!(test, metadata)

--- a/lib/tasks/swagger_rails_tasks.rake
+++ b/lib/tasks/swagger_rails_tasks.rake
@@ -9,6 +9,6 @@ if defined?(RSpec)
   desc 'Generate Swagger JSON files from integration specs'
   RSpec::Core::RakeTask.new('swaggerize') do |t|
     t.pattern = 'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
-    t.rspec_opts = [ '--format SwaggerRails::RSpec::Formatter', '--dry-run', '--order defined' ]
+    t.rspec_opts = [ '--format SwaggerRails::RSpec::Formatter', '--order defined' ]
   end
 end

--- a/spec/dummy/swagger/v1/swagger.json
+++ b/spec/dummy/swagger/v1/swagger.json
@@ -37,10 +37,28 @@
         ],
         "responses": {
           "201": {
-            "description": "valid request"
+            "description": "valid request",
+            "examples": {
+              "application/json": {
+                "errors": {
+                  "content": [
+                    "can't be blank"
+                  ]
+                }
+              }
+            }
           },
           "422": {
-            "description": "invalid request"
+            "description": "invalid request",
+            "examples": {
+              "application/json": {
+                "errors": {
+                  "content": [
+                    "can't be blank"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -59,7 +77,12 @@
         ],
         "responses": {
           "200": {
-            "description": "valid request"
+            "description": "valid request",
+            "examples": {
+              "application/json": [
+
+              ]
+            }
           }
         }
       }
@@ -84,10 +107,20 @@
         ],
         "responses": {
           "200": {
-            "description": "blog found"
+            "description": "blog found",
+            "examples": {
+              "application/json": {
+                "id": 1,
+                "title": "foo",
+                "content": "bar"
+              }
+            }
           },
           "404": {
-            "description": "blog not found"
+            "description": "blog not found",
+            "examples": {
+              "application/json": "null"
+            }
           }
         }
       }

--- a/spec/swagger_rails/test_visitor_spec.rb
+++ b/spec/swagger_rails/test_visitor_spec.rb
@@ -36,7 +36,7 @@ module SwaggerRails
         end
 
         it 'builds the path from values on the test object' do
-          expect(test).to have_received(:get).with('/resource/1', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/resource/1', {}, {})
         end
       end
 
@@ -53,10 +53,9 @@ module SwaggerRails
 
         it 'builds a body from value on the test object' do
           expect(test).to have_received(:post).with(
-            '/resource', {
-              params: "{\"foo\":\"bar\"}",
-              headers: { 'CONTENT_TYPE' => 'application/json' }
-            }
+            '/resource',
+            "{\"foo\":\"bar\"}",
+            { 'CONTENT_TYPE' => 'application/json' }
           )
         end
       end
@@ -72,7 +71,7 @@ module SwaggerRails
         end
 
         it 'builds query params from values on the test object' do
-          expect(test).to have_received(:get).with('/resource', { params: { 'type' => 'foo' }, headers: {} })
+          expect(test).to have_received(:get).with('/resource', { 'type' => 'foo' }, {})
         end
       end
 
@@ -89,10 +88,9 @@ module SwaggerRails
 
         it 'builds request headers from values on the test object' do
           expect(test).to have_received(:get).with(
-            '/resource', {
-              params: {},
-              headers: { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
-            }
+            '/resource',
+            {},
+            { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
           )
         end
       end
@@ -108,7 +106,7 @@ module SwaggerRails
         end
 
         it 'prepends the basePath to the request path' do
-          expect(test).to have_received(:get).with('/api/resource', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/api/resource', {}, {})
         end
       end
     end


### PR DESCRIPTION
Curious what you think about this. I'd like to include the results of the test requests in the examples sections of the swagger docs. I made some kind of hacky changes to get the data back out but it works. I'll spend a little time getting it cleaned up into something more presentable and adding test coverage. 

One thing I'm not 100% sure how to handle is non-JSON responses. The spec only shows JSON examples which are shown being returned as objects. I'm not sure what you'd do with other formats... I suppose just return them as a string.
