### PR TITLE
Fix params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.2
+cache: bundler
+install: bundle install && cd spec/dummy && bundle exec rake db:setup && cd -
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 swagger_rails
 =========
 
+[![Build Status](https://travis-ci.org/domaindrivendev/swagger_rails.svg)](https://travis-ci.org/domaindrivendev/swagger_rails)
+
 Generate API documentation, including a slick discovery UI and playground, directly from your rspec integration specs. Use the provided DSL to describe and test API operations in your spec files. Then, you can easily generate corresponding swagger.json files and serve them up with an embedded version of [swagger-ui](https://github.com/swagger-api/swagger-ui). Best of all, it requires minimal coding and maintenance, allowing you to focus on building an awesome API!
 
 And that's not all ...

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -11,7 +11,8 @@ module SwaggerRails
       path = build_path(metadata[:path_template], params_data)
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
-      test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+
+      test.send(metadata[:http_verb], path, body_or_params, headers)
     end
 
     def assert_response!(test, metadata)

--- a/lib/swagger_rails/test_visitor.rb
+++ b/lib/swagger_rails/test_visitor.rb
@@ -12,7 +12,11 @@ module SwaggerRails
       body_or_params = build_body_or_params(params_data)
       headers = build_headers(params_data, metadata[:consumes], metadata[:produces])
 
-      test.send(metadata[:http_verb], path, body_or_params, headers)
+      if Rails::VERSION::MAJOR >= 5
+        test.send(metadata[:http_verb], path, { params: body_or_params, headers: headers })
+      else
+        test.send(metadata[:http_verb], path, body_or_params, headers)
+      end
     end
 
     def assert_response!(test, metadata)

--- a/spec/swagger_rails/test_visitor_spec.rb
+++ b/spec/swagger_rails/test_visitor_spec.rb
@@ -36,7 +36,7 @@ module SwaggerRails
         end
 
         it 'builds the path from values on the test object' do
-          expect(test).to have_received(:get).with('/resource/1', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/resource/1', {}, {})
         end
       end
 
@@ -53,10 +53,9 @@ module SwaggerRails
 
         it 'builds a body from value on the test object' do
           expect(test).to have_received(:post).with(
-            '/resource', {
-              params: "{\"foo\":\"bar\"}",
-              headers: { 'CONTENT_TYPE' => 'application/json' }
-            }
+            '/resource',
+            "{\"foo\":\"bar\"}",
+            { 'CONTENT_TYPE' => 'application/json' }
           )
         end
       end
@@ -72,7 +71,7 @@ module SwaggerRails
         end
 
         it 'builds query params from values on the test object' do
-          expect(test).to have_received(:get).with('/resource', { params: { 'type' => 'foo' }, headers: {} })
+          expect(test).to have_received(:get).with('/resource', { 'type' => 'foo' }, {})
         end
       end
 
@@ -89,10 +88,9 @@ module SwaggerRails
 
         it 'builds request headers from values on the test object' do
           expect(test).to have_received(:get).with(
-            '/resource', {
-              params: {},
-              headers: { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
-            }
+            '/resource',
+            {},
+            { 'Date' => '2000-01-01', 'ACCEPT' => 'application/json' }
           )
         end
       end
@@ -108,7 +106,7 @@ module SwaggerRails
         end
 
         it 'prepends the basePath to the request path' do
-          expect(test).to have_received(:get).with('/api/resource', { params: {}, headers: {} })
+          expect(test).to have_received(:get).with('/api/resource', {}, {})
         end
       end
     end


### PR DESCRIPTION
Reverts the changes in https://github.com/domaindrivendev/swagger_rails/pull/9 and makes the change specific to Rails 5+. I'm not sure how you'd want to test the Rails 5 change... I don't see a great way to test that without adding a second rails instance or building some scripting to create the rails instance for testing.

I created this branch off of the Travis CI PR (https://github.com/domaindrivendev/swagger_rails/pull/21) to make sure it shows up as fixed. And based on https://travis-ci.org/drewish/swagger_rails/builds/159390811 it looks good.
