### PR TITLE
Simplify response header validation

### DIFF
--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -28,15 +28,10 @@ module Rswag
       def validate_headers!(headers)
         header_schema = @api_metadata[:response][:headers]
         return if header_schema.nil?
-        header_schema.each do |header_name, schema|
-          validate_header!(schema, header_name, headers[header_name.to_s])
-        end
-      end
 
-      def validate_header!(schema, header_name, header_value)
-        JSON::Validator.validate!(schema.merge(@global_metadata), header_value.to_json)
-      rescue JSON::Schema::ValidationError => ex
-        raise UnexpectedResponse, "Expected response headers #{header_name} to match schema: #{ex.message}"
+        header_schema.keys.each do |header_name|
+          raise UnexpectedResponse, "Expected response header #{header_name} to be present" if headers[header_name.to_s].nil?
+        end
       end
 
       def validate_body!(body)

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -96,9 +96,8 @@ module Rswag
 
           context 'response code matches & body does not' do
             let(:response) { OpenStruct.new(code: 200, body: '{}', headers: {
-              'X-Rate-Limit-Limit' => 'invalid',
-              'X-Rate-Limit-Remaining' => 'invalid',
-              'X-Rate-Limit-Reset' => 'invalid'
+              'X-Rate-Limit-Limit' => 1,
+              'X-Rate-Limit-Remaining' => 1
             }) }
             it { expect { call }.to raise_error UnexpectedResponse }
           end


### PR DESCRIPTION
Change to checks for the presence of required headers instead of using JSON::Validator.

This is to fix the wrong assumption that header using JSON format to represent values introduced in https://github.com/domaindrivendev/rswag/pull/32
