### PR TITLE
unable use key and value

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -28,7 +28,7 @@ module Rswag
 
       def build_body(example)
         body_parameter = parameters_in(:body).first
-        body_parameter.nil? ? '' : example.send(body_parameter[:name]).to_json
+        body_parameter.nil? ? '' : example.send(body_parameter[:name])
       end
 
       def build_headers(example)


### PR DESCRIPTION
i can't use key and value because of to use 'to_json' method.
this made only the key.
ex)
param { phone: '01022223333', name: 'name' } 
request param {\"phone\":\"01022223333\",\"name\":\"name\"} => nil