### PR TITLE
Allow parameters to be defined only by schema references

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -36,7 +36,9 @@ module Rswag
       end
 
       def parameter(attributes)
-        attributes[:required] = true if attributes[:in].to_sym == :path
+        if attributes.fetch(:in, nil) == :path
+          attributes[:required] = true
+        end
 
         if metadata.has_key?(:operation)
           metadata[:operation][:parameters] ||= []

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -43,12 +43,16 @@ module Rswag
 
       private
 
+      def extract_uniq_param_identifier_from(operation_param)
+        operation_param[:name] || operation_param['$ref']
+      end
+
       def parameters_in(location)
         path_item_params = @api_metadata[:path_item][:parameters] || []
         operation_params = @api_metadata[:operation][:parameters] || []
         applicable_params = operation_params
           .concat(path_item_params)
-          .uniq { |p| p[:name] } # operation params should override path_item params
+          .uniq { |p| extract_uniq_param_identifier_from(p) } # operation params should override path_item params
 
         applicable_params
           .map { |p| p['$ref'] ? resolve_parameter(p['$ref']) : p } # resolve any references
@@ -57,8 +61,8 @@ module Rswag
       end
 
       def resolve_parameter(ref)
-        defined_params = @global_metadata[:parameters] 
-        key = ref.sub('#/parameters/', '')
+        defined_params = @global_metadata[:parameters]
+        key = ref.sub('#/parameters/', '').to_sym
         raise "Referenced parameter '#{ref}' must be defined" unless defined_params && defined_params[key]
         defined_params[key]
       end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -162,7 +162,7 @@ module Rswag
           before do
             api_metadata[:operation][:parameters] << { '$ref' => '#/parameters/comment' }
             global_metadata[:parameters] = {
-              'comment' => { name: 'comment', in: :body, schema: { type: 'object' } }
+              comment: { name: 'comment', in: :body, schema: { type: 'object' } }
             }
             allow(example).to receive(:comment).and_return(text: 'Some comment')
           end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -41,7 +41,7 @@ describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
   end
 
   path '/blogs/{id}' do
-    parameter name: :id, :in => :path, :type => :string
+    parameter({ "$ref" => "#/parameters/id_path_parameter" })
 
     get 'Retrieves a blog' do
       tags 'Blogs'

--- a/test-app/spec/swagger_helper.rb
+++ b/test-app/spec/swagger_helper.rb
@@ -20,6 +20,14 @@ RSpec.configure do |config|
         version: 'v1'
       },
       paths: {},
+      parameters: {
+        id_path_parameter: {
+          name: :id,
+          type: :string,
+          in: :path,
+          required: true
+        },
+      },
       definitions: {
         errors_object: {
           type: 'object',

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -70,10 +70,7 @@
     "/blogs/{id}": {
       "parameters": [
         {
-          "name": "id",
-          "in": "path",
-          "type": "string",
-          "required": true
+          "$ref": "#/parameters/id_path_parameter"
         }
       ],
       "get": {
@@ -116,6 +113,14 @@
           }
         }
       }
+    }
+  },
+  "parameters": {
+    "id_path_parameter": {
+      "name": "id",
+      "type": "string",
+      "in": "path",
+      "required": true
     }
   },
   "definitions": {


### PR DESCRIPTION
This should allow for larger schemas to be defined in a more compact fashion - please see the `swagger_helper` and integration spec changes in the test-app.