### PR TITLE
Add Swaggerable to allow dynamic definition for model

### DIFF
--- a/rswag/lib/rswag.rb
+++ b/rswag/lib/rswag.rb
@@ -1,5 +1,6 @@
 require 'rswag/version'
 require 'rswag/specs'
+require 'rswag/models/swaggerable'
 require 'rswag/api'
 require 'rswag/ui'
 

--- a/rswag/lib/rswag/models/swaggerable.rb
+++ b/rswag/lib/rswag/models/swaggerable.rb
@@ -1,0 +1,76 @@
+module Rswag
+  module Models
+    module Swaggerable
+      extend ActiveSupport::Concern
+
+      included do
+        @swagger_custom_property_definitions = {}
+      end
+
+      class_methods do
+        def swagger_definition(serializer_klass = "#{name}Serializer".constantize)
+          serializer = serializer_klass.new(new)
+
+          definition = {
+            type: :object,
+            required: swagger_required_attributes,
+            properties: swagger_properties(serializer)
+          }
+
+          definition[:properties].merge!(@swagger_custom_property_definitions)
+          definition
+        end
+
+        def swagger_attribute(attribute, type)
+          @swagger_custom_property_definitions[attribute] = { type: type }
+        end
+
+        def swagger_properties(serializer)
+          properties = {}
+
+          serializer.attributes.keys.each do |key|
+            properties[key] = { type: attribute_types[key.to_s].type }
+          end
+
+          swagger_model_associations_properties(serializer, properties)
+
+          properties
+        end
+
+        def swagger_model_associations_properties(serializer, properties)
+          serializer._reflections.each do |key, value|
+            model = key.to_s.singularize.classify.constantize
+            serializer = swagger_association_serializer(model, value.options)
+
+            case value
+            when ActiveModel::Serializer::HasManyReflection
+              swagger_definition = { type: 'array', items: model.swagger_definition(serializer) }
+            when ActiveModel::Serializer::BelongsToReflection
+              swagger_definition = model.swagger_definition(serializer)
+            end
+
+            properties[key] = swagger_definition
+          end
+
+          properties
+        end
+
+        def swagger_association_serializer(model, options)
+          return options[:serializer] if options.key?(:serializer)
+
+          "#{model.name}Serializer".constantize
+        end
+
+        def swagger_required_attributes
+          presence_validators = validators.select do |validator|
+            validator.class == ActiveRecord::Validations::PresenceValidator
+          end
+
+          presence_validators.each_with_object([]) do |validator, required_attributes|
+            required_attributes.concat(validator.attributes)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I don't know if something like this would be useful to the project.  I ended up writing this to close the last mile for our application where the schema could drift from the model.

Basically with this in the model I can do a `include Rswag::Models::Swaggerable`.  Then I can call `Model.swagger_definition` on the model to get the definition dynamically for that model.  This is used then in my swagger_helper.rb in the swagger_doc as 

```
definitions: {
  model: Model.swagger_definition
}
```

One main assumption made is that all models being swaggerized have a corresponding serializer.

There is also a helper method to be able to override found attributes with a different type. This was primarily used when using `serialize` as the underlying type is always a string and that's not what the actual type is. So in the model there is a helper method called `swagger_attribute(attribute, type)` that will override what the introspection finds.  This is also necessary when using an enum.

Let me know if this sounds interesting and if so what other things you'd want cleaned up before merging.  If it's not interesting, no worries, but it really helped make our tests more coupled to implementation so schema drift did not occur so thought I would share back.