### PR TITLE
Can we use JSON::Validator.fully_validate() to get better error messages?

### DIFF
--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -40,13 +40,12 @@ module Rswag
         response_schema = @api_metadata[:response][:schema]
         return if response_schema.nil?
 
-        begin
-          validation_schema = response_schema
-            .merge('$schema' => 'http://tempuri.org/rswag/specs/extended_schema')
-            .merge(@global_metadata.slice(:definitions))
-          JSON::Validator.validate!(validation_schema, body)
-        rescue JSON::Schema::ValidationError => ex
-          raise UnexpectedResponse, "Expected response body to match schema: #{ex.message}"
+        validation_schema = response_schema
+          .merge('$schema' => 'http://tempuri.org/rswag/specs/extended_schema')
+          .merge(@global_metadata.slice(:definitions))
+        error_messages = JSON::Validator.fully_validate(validation_schema, body)
+        if error_messages.any?
+          raise UnexpectedResponse, "Expected response body to match schema: #{error_messages[0]}"
         end
       end
     end


### PR DESCRIPTION
When composing together two or more schemas, the error messages are not really helpful. 
```
            schema allOf: [
              {"$ref": "#/definitions/response_envelope"},
              {
                type: :object,
                properties: {
                  results: {
                    type: :array,
                    items: { "$ref": "#/definitions/my_object" }
                  }
                },
                required: [:results]
              }
            ]
```

The usual error would be 

> Expected response body to match schema: The property '#/' of type object did not match all of the required schemas

With this change you get
       

> Expected response body to match schema: The property '#/' of type object did not match all of the required schemas. The schema specific errors were:
> 
>        - allOf #1:
>            - The property '#/results/1' contains additional properties ["some-property"] outside of the schema when none are allowed
>            - The property '#/results/0' contains additional properties ["some-property"] outside of the schema when none are allowed
