### PR TITLE
Allows for parameters to be defined without the 'in' key defined.

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -36,7 +36,9 @@ module Rswag
       end
 
       def parameter(attributes)
-        attributes[:required] = true if attributes[:in].to_sym == :path
+        if attributes[:in] && attributes[:in].to_sym == :path
+          attributes[:required] = true
+        end
 
         if metadata.has_key?(:operation)
           metadata[:operation][:parameters] ||= []

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -120,6 +120,15 @@ module Rswag
             )
           end
         end
+
+        context "when 'in' parameter key is not defined" do
+          before { subject.parameter(name: :id) }
+          let(:api_metadata) { { operation: {} } }
+
+          it "does not require the 'in' parameter key" do
+            expect(api_metadata[:operation][:parameters]).to match([ name: :id ])
+          end
+        end
       end
 
       describe '#response(code, description)' do


### PR DESCRIPTION
I'm new to using Swagger docs, however I have seen in some of my companies existing Swagger docs that they're using a $ref to define their parameters that get used a lot. I however cannot generate Swagger docs like this with this gem as it errors out when a `:in` parameter key isn't defined. This PR should fix that issue.