### PR TITLE
Add alternative way to load gem for optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
     ```ruby
     gem 'rswag'
     ```
+    or if you like to avoid loading rspec in other bundler groups.
+    
+    ```ruby
+    # Gemfile
+    gem 'rswag-api'
+    gem 'rswag-ui'
+
+    groups :test do
+      gem 'rspec-rails'
+      gem 'rswag-specs'
+    end
+    ```
+
 
 2. Run the install generator
 


### PR DESCRIPTION
Most projects don't load rspec in production mode. So makes sense to add it to guide.