### PR TITLE
Fix travis to not cleanup when publishing rswag-ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ jobs:
         gemspec: rswag-ui.gemspec
         provider: rubygems
         api_key: $RUBYGEMS_API_KEY
+        skip_cleanup: true
         on:
           branch: master
           tags: true


### PR DESCRIPTION
This is to keep `node_modules` directory. Fixes #124 