### PR TITLE
Skip adding query params if their value is nil

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -54,7 +54,7 @@ module Rswag
         definitions[key]
       end
 
-      def add_verb(request, metadata) 
+      def add_verb(request, metadata)
         request[:verb] = metadata[:operation][:verb]
       end
 
@@ -67,8 +67,11 @@ module Rswag
           end
 
           parameters.select { |p| p[:in] == :query }.each_with_index do |p, i|
-            template.concat(i == 0 ? '?' : '&')
-            template.concat(build_query_string_part(p, example.send(p[:name])))
+            value = example.send(p[:name])
+            unless value.nil?
+              template.concat(i == 0 ? '?' : '&')
+              template.concat(build_query_string_part(p, value))
+            end
           end
         end
       end
@@ -104,7 +107,7 @@ module Rswag
         end
 
         # Content-Type header
-        consumes = metadata[:operation][:consumes] || swagger_doc[:consumes] 
+        consumes = metadata[:operation][:consumes] || swagger_doc[:consumes]
         if consumes
           content_type = example.respond_to?(:'Content-Type') ? example.send(:'Content-Type') : consumes.first
           tuples << [ 'Content-Type', content_type ]

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -66,13 +66,12 @@ module Rswag
             template.gsub!("{#{p[:name]}}", example.send(p[:name]).to_s)
           end
 
-          parameters.select { |p| p[:in] == :query }.each_with_index do |p, i|
+          query = parameters.select { |p| p[:in] == :query }.map do |p|
             value = example.send(p[:name])
-            unless value.nil?
-              template.concat(i == 0 ? '?' : '&')
-              template.concat(build_query_string_part(p, value))
-            end
-          end
+            build_query_string_part(p, value) unless value.nil?
+          end.compact.join('&')
+          
+          template.concat('?' + query) unless query.empty?
         end
       end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -9,7 +9,7 @@ module Rswag
       before do
         allow(config).to receive(:get_swagger_doc).and_return(swagger_doc)
       end
-      let(:config) { double('config') } 
+      let(:config) { double('config') }
       let(:swagger_doc) { {} }
       let(:example) { double('example') }
       let(:metadata) do
@@ -47,13 +47,15 @@ module Rswag
           before do
             metadata[:operation][:parameters] = [
               { name: 'q1', in: :query, type: :string },
-              { name: 'q2', in: :query, type: :string }
+              { name: 'q2', in: :query, type: :string },
+              { name: 'q3', in: :query, type: :string }
             ]
             allow(example).to receive(:q1).and_return('foo')
             allow(example).to receive(:q2).and_return('bar')
+            allow(example).to receive(:q3).and_return(nil)
           end
 
-          it "builds the query string from example values" do
+          it "builds the query string from example values, skipping nils" do
             expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
           end
         end


### PR DESCRIPTION
This PR allows you to define query params as `nil` in your specs, and for the RequestFactory not to add them to the URL in this case.

You are still required to define all params with `let`, even if you define them as nil, and you can still add an empty string to the URL by defining them as `""`.

I know this is a slight change in functionality, but I'm sure this is what most people would mean when they say a query param is `nil` in a spec.