### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
     gem 'rswag-api'
     gem 'rswag-ui'
 
-    groups :test do
+    group :test do
       gem 'rspec-rails'
       gem 'rswag-specs'
     end


### PR DESCRIPTION
I fixed Gemfile example.

`groups` will not work.

```
$ bundle install

[!] There was an error parsing `Gemfile`: Undefined local variable or method `groups' for Gemfile. Bundler cannot continue.

 #  from /Users/hoshino/go/src/github.com/hoshinotsuyoshi/some_rails_app/Gemfile:117
 #  -------------------------------------------
 #
 >  groups :test do
 #    gem 'rspec-rails'
 #  -------------------------------------------
```

`group` will work well.