### PR TITLE
Upgrade Swagger UI to 3.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 
 |Rswag Version|Swagger (OpenAPI) Spec.|swagger-ui|
 |----------|----------|----------|
-|[master](https://github.com/domaindrivendev/rswag/tree/master)|2.0|3.13.2|
+|[master](https://github.com/domaindrivendev/rswag/tree/master)|2.0|3.17.1|
 |[2.0.3](https://github.com/domaindrivendev/rswag/tree/2.0.3)|2.0|3.13.2|
 |[1.6.0](https://github.com/domaindrivendev/rswag/tree/1.6.0)|2.0|2.2.5|
 

--- a/rswag-ui/package-lock.json
+++ b/rswag-ui/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.13.2.tgz",
-      "integrity": "sha1-EL9SK9J0q2SU0r0Nuvn+2ibbHKI="
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.17.1.tgz",
+      "integrity": "sha1-2wjtaBvPuhMUn35hD0izbNTBfeg="
     }
   }
 }

--- a/rswag-ui/package.json
+++ b/rswag-ui/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "3.13.2"
+    "swagger-ui-dist": "3.17.1"
   }
 }


### PR DESCRIPTION
At this time, v3.17.1 is the latest release:
https://github.com/swagger-api/swagger-ui/releases