### PR TITLE
Upgrade Swagger UI to 3.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 
 |Rswag Version|Swagger (OpenAPI) Spec.|swagger-ui|
 |----------|----------|----------|
-|[master](https://github.com/domaindrivendev/rswag/tree/master)|2.0|3.17.1|
+|[master](https://github.com/domaindrivendev/rswag/tree/master)|2.0|3.17.3|
 |[2.0.4](https://github.com/domaindrivendev/rswag/tree/2.0.4)|2.0|3.17.1|
 |[1.6.0](https://github.com/domaindrivendev/rswag/tree/1.6.0)|2.0|2.2.5|
 

--- a/rswag-ui/package-lock.json
+++ b/rswag-ui/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.17.1.tgz",
-      "integrity": "sha1-2wjtaBvPuhMUn35hD0izbNTBfeg="
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.17.3.tgz",
+      "integrity": "sha1-37lkCMzEZ3UVX3NpGQxdSyAW/lw="
     }
   }
 }

--- a/rswag-ui/package.json
+++ b/rswag-ui/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "3.17.1"
+    "swagger-ui-dist": "3.17.3"
   }
 }


### PR DESCRIPTION
At this time, v3.17.3 is the latest release:
https://github.com/swagger-api/swagger-ui/releases