### PR TITLE
body payload fix

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -150,7 +150,7 @@ module Rswag
 
       def build_json_payload(parameters, example)
         body_param = parameters.select { |p| p[:in] == :body }.first
-        body_param ? example.send(body_param[:name]).to_json : nil
+        body_param ? example.send(body_param[:name]) : nil
       end
     end
   end

--- a/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
@@ -58,7 +58,7 @@ module Rswag
         it "submits a request built from metadata and 'let' values" do
           expect(subject).to have_received(:put).with(
             '/blogs/1/comments/2?q1=foo&api_key=fookey',
-            "{\"text\":\"Some comment\"}",
+            { text: 'Some comment' },
             { 'CONTENT_TYPE' => 'application/json' }
           )
         end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -155,7 +155,7 @@ module Rswag
             end
 
             it "serializes first 'body' parameter to JSON string" do
-              expect(request[:payload]).to eq("{\"text\":\"Some comment\"}")
+              expect(request[:payload]).to eq({ text: 'Some comment' })
             end
           end
 


### PR DESCRIPTION
Do not know if it is related only to Rails 4.2.10

but now we receive right params

instead of
```ruby
[1] pry(#<API::V1::WithdrawalsController>)> params
=> {"{\"currency\":\"BTC\"}"=>nil, "controller"=>"api/v1/withdrawals", "action"=>"index", "withdrawal"=>{}}
```

we now have
```ruby
[1] pry(#<API::V1::WithdrawalsController>)> params
=> {currency => "BTC", "controller"=>"api/v1/withdrawals", "action"=>"index", "withdrawal"=>{}}
```

here is our spec definition

```ruby
  path '/withdrawals' do
    get 'Retrieves user withdrawals by currency' do
      tags 'Withdrawals'
      consumes 'application/json'

      include_context :api_v1_auth

      parameter name: :payload, in: :body, schema: {
        type: :object,
        properties: {
          currency: { type: :string }
        },
        required: %w[currency]
      }

      before { create :withdrawal, member: token.member }

      response '200', 'withdrawals are listed' do
        let(:payload) { { currency: 'BTC' } }

        schema type: :array, items: { '$ref': '#/definitions/withdrawal' }

        run_test! do |responce|
          expect(JSON.parse(response.body).count).to eq 1
        end
      end
    end
  end
```