### PR TITLE
Provide alternate rake task name to ensure test environment is loaded…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 4. Generate the Swagger JSON file(s)
 
     ```ruby
-    rake rswag:specs:swaggerize
+    rake spec:swaggerize
     ```
+
+    (Deprecated) `rake rswag:specs:swaggerize`. If using `dotenv-rails` the test environment is not loaded unless `RAILS_ENV=test` is set.
 
 5. Spin up your app and check out the awesome, auto-generated docs at _/api-docs_!
 

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -1,18 +1,22 @@
 require 'rspec/core/rake_task'
 
+namespace :spec do
+  desc 'Generate Swagger JSON files from integration specs'
+  RSpec::Core::RakeTask.new('swaggerize') do |t|
+    t.pattern = 'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
+
+    # NOTE: rspec 2.x support
+    if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.swagger_dry_run
+      t.rspec_opts = [ '--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined' ]
+    else
+      t.rspec_opts = [ '--format Rswag::Specs::SwaggerFormatter', '--order defined' ]
+    end
+  end
+end
+
 namespace :rswag do
   namespace :specs do
-
-    desc 'Generate Swagger JSON files from integration specs'
-    RSpec::Core::RakeTask.new('swaggerize') do |t|
-      t.pattern = 'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
-
-      # NOTE: rspec 2.x support
-      if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.swagger_dry_run
-        t.rspec_opts = [ '--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined' ]
-      else
-        t.rspec_opts = [ '--format Rswag::Specs::SwaggerFormatter', '--order defined' ]
-      end
-    end
+    desc '(Deprecated) Use spec:swaggerize or specify RAILS_ENV=test if using dotenv.'
+    task :swaggerize => "spec:swaggerize"
   end
 end


### PR DESCRIPTION
… with dotenv-rails.

New rake task name is consistent with how dotenv-rails detects spec running to set RAILS_ENV=test, https://github.com/bkeepers/dotenv/blob/a1fa729e5e6d96114f4fed9bcf19842a8e2776aa/lib/dotenv/rails.rb#L12