### PR TITLE
Update comment in swagger_helper template

### DIFF
--- a/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
+++ b/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
   config.swagger_root = Rails.root.to_s + '/swagger'
 
   # Define one or more Swagger documents and provide global metadata for each one
-  # When you run the 'rswag:specs:to_swagger' rake task, the complete Swagger will
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
   # be generated at the provided relative path under swagger_root
   # By default, the operations defined in spec files are added to the first
   # document below. You can override this behavior by adding a swagger_doc tag to the


### PR DESCRIPTION
Quick fix to the `swagger_helper` template since `rswag:specs:to_swagger` does not seem to be a valid task.