### PR TITLE
Call disable_monkey_patching! for RSpec configuration, to fix IRB context warning in Rails console

### DIFF
--- a/rswag-specs/spec/generators/rswag/specs/install_generator_spec.rb
+++ b/rswag-specs/spec/generators/rswag/specs/install_generator_spec.rb
@@ -4,7 +4,7 @@ require 'generators/rswag/specs/install/install_generator'
 module Rswag
   module Specs
 
-    describe InstallGenerator do
+    RSpec.describe InstallGenerator do
       include GeneratorSpec::TestCase
       destination File.expand_path('../tmp', __FILE__)
 

--- a/rswag-specs/spec/rswag/specs/configuration_spec.rb
+++ b/rswag-specs/spec/rswag/specs/configuration_spec.rb
@@ -3,7 +3,7 @@ require 'rswag/specs/configuration'
 module Rswag
   module Specs
 
-    describe Configuration do
+    RSpec.describe Configuration do
       subject { described_class.new(rspec_config) }
 
       let(:rspec_config) { OpenStruct.new(swagger_root: swagger_root, swagger_docs: swagger_docs) }

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -3,7 +3,7 @@ require 'rswag/specs/example_group_helpers'
 module Rswag
   module Specs
 
-    describe ExampleGroupHelpers do
+    RSpec.describe ExampleGroupHelpers do
       subject { double('example_group') }
 
       before do

--- a/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
@@ -3,7 +3,7 @@ require 'rswag/specs/example_helpers'
 module Rswag
   module Specs
 
-    describe ExampleHelpers do
+    RSpec.describe ExampleHelpers do
       subject { double('example') }
 
       before do
@@ -12,7 +12,7 @@ module Rswag
         allow(config).to receive(:get_swagger_doc).and_return(swagger_doc)
         stub_const('Rswag::Specs::RAILS_VERSION', 3)
       end
-      let(:config) { double('config') } 
+      let(:config) { double('config') }
       let(:swagger_doc) do
         {
           securityDefinitions: {

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -3,13 +3,13 @@ require 'rswag/specs/request_factory'
 module Rswag
   module Specs
 
-    describe RequestFactory do
+    RSpec.describe RequestFactory do
       subject { RequestFactory.new(config) }
 
       before do
         allow(config).to receive(:get_swagger_doc).and_return(swagger_doc)
       end
-      let(:config) { double('config') } 
+      let(:config) { double('config') }
       let(:swagger_doc) { {} }
       let(:example) { double('example') }
       let(:metadata) do

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -3,13 +3,13 @@ require 'rswag/specs/response_validator'
 module Rswag
   module Specs
 
-    describe ResponseValidator do
+    RSpec.describe ResponseValidator do
       subject { ResponseValidator.new(config) }
 
       before do
         allow(config).to receive(:get_swagger_doc).and_return(swagger_doc)
       end
-      let(:config) { double('config') } 
+      let(:config) { double('config') }
       let(:swagger_doc) { {} }
       let(:example) { double('example') }
       let(:metadata) do

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -3,8 +3,8 @@ require 'ostruct'
 
 module Rswag
   module Specs
-    
-    describe SwaggerFormatter do
+
+    RSpec.describe SwaggerFormatter do
       subject { described_class.new(output, config) }
 
       # Mock out some infrastructure
@@ -47,7 +47,7 @@ module Rswag
       end
 
       describe '#stop' do
-        before do 
+        before do
           FileUtils.rm_r(swagger_root) if File.exists?(swagger_root)
           allow(config).to receive(:swagger_docs).and_return(
             'v1/swagger.json' => { info: { version: 'v1' } },

--- a/test-app/spec/features/swagger_ui_spec.rb
+++ b/test-app/spec/features/swagger_ui_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'swagger-ui', js: true do
+RSpec.feature 'swagger-ui', js: true do
 
   scenario 'browsing api-docs' do
     visit '/api-docs'

--- a/test-app/spec/integration/auth_tests_spec.rb
+++ b/test-app/spec/integration/auth_tests_spec.rb
@@ -1,6 +1,6 @@
 require 'swagger_helper'
 
-describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' do
+RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' do
 
   path '/auth-tests/basic' do
     post 'Authenticates with basic auth' do

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -1,6 +1,6 @@
 require 'swagger_helper'
 
-describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
+RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
   let(:api_key) { 'fake_key' }
 
   path '/blogs' do

--- a/test-app/spec/rake/rswag_specs_swaggerize_spec.rb
+++ b/test-app/spec/rake/rswag_specs_swaggerize_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 require 'rake'
 
-describe 'rswag:specs:swaggerize' do
+RSpec.describe 'rswag:specs:swaggerize' do
   let(:swagger_root) { Rails.root.to_s + '/swagger' }
-  before do 
+  before do
     TestApp::Application.load_tasks
     FileUtils.rm_r(swagger_root) if File.exists?(swagger_root)
   end


### PR DESCRIPTION
Fixes the IRB warning in #151.

This disables the RSpec monkey patching. It means that you need to change any top-level `describe` to `RSpec.describe`, but it should only be one change at the top of each spec file. You can continue to use `describe` and `context` within the block.

This will affect the specs of any Rails application that uses the `rswag` gem, but I think this is a best-practice now, and it's good to encourage people to use the `disable_monkey_patching!` option. 