### PR TITLE
Fix installation instructions for separate gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
     ```ruby
     rails g rswag:install
     ```
+    
+    Or run the install generators for each package separately if you installed Rswag as separate gems, as indicated above:
+    
+    ```ruby
+    rails g rswag:api:install rswag:ui:install
+    RAILS_ENV=test rails g rswag:specs:install
+    ```
 
 3. Create an integration spec to describe and test your API.
 


### PR DESCRIPTION
When installing separate gems, `rails g rswag:install` doesn't work. Instead, you need to run `rails g rswag:api:install rswag:ui:install` and `RAILS_ENV=test rails g rswag:specs:install`, as per @abevoelker's comment in https://github.com/domaindrivendev/rswag/issues/128.