### PR TITLE
add example as metadata caller in run_test rspec 2 leaf

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -79,7 +79,7 @@ module Rswag
           end
 
           it "returns a #{metadata[:response][:code]} response" do
-            assert_response_matches_metadata(metadata)
+            assert_response_matches_metadata(example.metadata)
             block.call(response) if block_given?
           end
         else


### PR DESCRIPTION
This fixes a bug when trying to use the run_test! example group helper method
in Rspec 2.x. Previously this would fire an "undefined local variable or method
'metadata' error" as the intended caller (example) was not referenced.