### PR TITLE
Update swagger_helper.rb

### DIFF
--- a/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
+++ b/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
@@ -4,7 +4,7 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.to_s + '/swagger'
+  config.swagger_root = Rails.root.join('swagger').to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will


### PR DESCRIPTION
Use standard filesystem helpers to avoid OS specific slash errors.