### PR TITLE
Add a 'rake rswag' that runs swaggerize as the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
     rake rswag:specs:swaggerize
     ```
 
+    This common command is also aliased as `rake rswag`.
+
 5. Spin up your app and check out the awesome, auto-generated docs at _/api-docs_!
 
 ## The rspec DSL ##

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -16,3 +16,6 @@ namespace :rswag do
     end
   end
 end
+
+task :rswag => ['rswag:specs:swaggerize']
+


### PR DESCRIPTION
What do you think of this idea? I find myself running `rake rswag:specs:swaggerize` very frequently, and it's quite a mouthful for such a common command. I think others could benefit from it being aliased to `rake rswag`.