### PR TITLE
Allow optional parameter named 'include'

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -33,7 +33,11 @@ module Rswag
         (operation_params + path_item_params + security_params)
           .map { |p| p['$ref'] ? resolve_parameter(p['$ref'], swagger_doc) : p }
           .uniq { |p| p[:name] }
-          .reject { |p| p[:required] == false && !example.respond_to?(p[:name]) }
+          .reject { |p|
+            p[:required] == false &&
+            (!example.respond_to?(p[:name])) ||
+            (example.respond_to?(p[:name]) && example.send(p[:name]).is_a?(RSpec::Matchers::BuiltIn::Include))
+          }
       end
 
       def derive_security_params(metadata, swagger_doc)

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -127,6 +127,34 @@ module Rswag
           end
         end
 
+        context 'optional parameter named include' do
+          context 'not included' do
+            before do
+              metadata[:operation][:parameters] = [
+                { name: 'include', in: :query, type: :string, required: false }
+              ]
+              allow(example).to receive(:include).and_return(RSpec::Matchers::BuiltIn::Include.new)
+            end
+
+            it 'builds request hash without them' do
+              expect(request[:path]).to eq('/blogs')
+            end
+          end
+
+          context 'included' do
+            before do
+              metadata[:operation][:parameters] = [
+                { name: 'include', in: :query, type: :string, required: false }
+              ]
+              allow(example).to receive(:include).and_return('foo')
+            end
+
+            it 'builds request hash without them' do
+              expect(request[:path]).to eq('/blogs?include=foo')
+            end
+          end
+        end
+
         context "consumes content" do
           before do
             metadata[:operation][:consumes] = [ 'application/json', 'application/xml' ]


### PR DESCRIPTION
A parameter named include was creating an issue, because even when not
required, it wasn't being rejected because the `respond_to?` check was
always returning `true`. An `example` was responding to the built-in
RSpec method `include`, versus looking for the memoized `let` variable.

This closes #188 

I think I'd ideally like to have checked this another way, but I don't see a way to
differentiate (on an example) whether a method is defined via a `let` or it's a
method that the example responds to

The reason behind this PR is because the `include` keyword as a query parameter
is a jsonapi standard convention, so I can't well change the parameter name and
follow the standard.

There is a workaround that kind-of works, setting a `let(:include) { {} }` before each
test; but that results in a URL with an empty parameter and isn't intuitive, or
correct. 

This PR allows us to generate documentation without having to specify the
optional `include` query parameter

Update: I need to look into this in depth, again. This still breaks the `include` matcher
when you use a `let(:include)`. I think that's an rspec issue though and I'm not sure 
that's something we can overcome