### PR TITLE
Gemfile: Use exact sqlite3 versions to fix the build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,12 @@ gem 'rails', "#{rails_version}"
 
 case rails_version.split('.').first
 when '3'
+  gem 'sqlite3', '~> 1.3.5'
   gem 'strong_parameters'
 when '4', '5'
   gem 'responders'
+  gem 'sqlite3', '~> 1.3.6'
 end
-
-gem 'sqlite3'
 
 gem 'rswag-api', path: './rswag-api'
 gem 'rswag-ui', path: './rswag-ui'


### PR DESCRIPTION
This PR is about **fixing the build failure** re: exact version of `sqlite3` used by Rails.

  - Avoids `Gem::LoadError` about sqlite3 1.3.6 needs

See https://stackoverflow.com/a/54729071/267348 for more details about why this happens.