### PR TITLE
add custom_property support

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -28,6 +28,12 @@ module Rswag
         metadata[:operation][:description] = value
       end
 
+      def custom_property(attributes)
+        property_name = attributes[:name]
+        property_value = attributes[:value]
+        metadata[:operation][property_name] = property_value
+      end
+
       # These are array properties - note the splat operator
       [ :tags, :consumes, :produces, :schemes ].each do |attr_name|
         define_method(attr_name) do |*value|

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -1,4 +1,5 @@
 require 'rswag/specs/example_group_helpers'
+require 'pry'
 
 module Rswag
   module Specs
@@ -83,6 +84,18 @@ module Rswag
             deprecated: true,
             security: { api_key: [] }
           )
+        end
+      end
+
+      describe '#custom_property(attributes)' do
+        before do
+          subject.custom_property(name: 'x-something', value: 'x-value')
+        end
+
+        let(:api_metadata) { { operation: {} } }
+
+        it "adds to the 'operation' metadata" do
+          expect(api_metadata[:operation]['x-something']).to eq('x-value')
         end
       end
 


### PR DESCRIPTION
Add support for custom properties. This is specifically useful for OpenAPI extensions such as the one used by Amazon API Gateway which allows additional properties like 'x-amazon-apigateway-integration'.