### PR TITLE
[Issue #178] Add support for documenting an error response

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -97,6 +97,29 @@ module Rswag
           end
         end
       end
+
+      def document_response_without_test!
+        # NOTE: rspec 2.x support
+        if RSPEC_VERSION < 3
+          before do
+            submit_request(example.metadata)
+          end
+
+          it 'adds documentation without testing the response' do
+            # Only check that the response is present
+            expect(example.metadata[:response]).to be_present
+          end
+        else
+          before do |example|
+            submit_request(example.metadata)
+          end
+
+          it 'adds documentation without testing the response' do |example|
+            # Only check that the response is present
+            expect(example.metadata[:response]).to be_present
+          end
+        end
+      end
     end
   end
 end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
           expect(response.body).to include("can't be blank")
         end
       end
+
+      response '500', 'Internal Server Error' do
+        schema '$ref' => '#/definitions/errors_object'
+        examples 'application/json' => { "errors": ["Internal Server Error"] }
+
+        document_response_without_test!
+      end
     end
 
     get 'Searches blogs' do


### PR DESCRIPTION
Solution for https://github.com/domaindrivendev/rswag/issues/178

Add support for documenting a response without validating it as in run_test!