### PR TITLE
Update contributing instructions. Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [2.0.6] - 2019-10-03
+### Added
 - Support for Rails 6 [#228](https://github.com/rswag/rswag/pull/228)
 - Support for Windows paths [#176](https://github.com/rswag/rswag/pull/176)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# rswag
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Support for Rails 6 [#228](https://github.com/rswag/rswag/pull/228)
+- Support for Windows paths [#176](https://github.com/rswag/rswag/pull/176)
+### Changed
+- Show response body when error code is not expected [#117](https://github.com/rswag/rswag/pull/177)
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+## [2.0.5] - 2018-07-10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,17 @@ bundle exec rspec
 Push to your fork and [submit a Pull Request][pr].
 
 [pr]: https://github.com/rswag/rswag/compare/
+
+## Release
+(for maintainers)
+
+Update the changelog.md, putting the new version number in and moving the Unreleased marker.
+
+Merge the changes into master you wish to release.
+
+Add and push a new git tag, annotated tags preferred:
+```
+git tag -s 2.0.6 -m 'v2.0.6'
+```
+
+Travis will detect the tag and release all gems with that tag version number.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,36 @@
 # Contributing
 
-Fork, then clone the repo:
-
+## Fork, then clone the repo:
 ```
-git clone git@github.com:domaindrivendev/rswag.git
+git clone git@github.com:rswag/rswag.git
 cd rswag
 ```
 
+## Build
 Set up your machine:
-
+```
+./ci/build.sh
+```
+Or manually
 ```
 bundle
-cd spec/dummy
+cd test-app
 bundle exec rake db:setup
+cd -
+
+cd rswag-ui
+npm install
 cd -
 ```
 
+## Test
 Make sure the tests pass:
-
 ```
+./ci/test.sh
+```
+or manually
+```
+cd test-app
 bundle exec rspec
 ```
 
@@ -30,4 +42,4 @@ bundle exec rspec
 
 Push to your fork and [submit a Pull Request][pr].
 
-[pr]: https://github.com/domaindrivendev/rswag/compare/
+[pr]: https://github.com/rswag/rswag/compare/

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160218212104) do
+ActiveRecord::Schema.define(version: 2016_02_18_212104) do
 
   create_table "blogs", force: :cascade do |t|
     t.string "title"


### PR DESCRIPTION
Two changes:
- Update Contributing instructions.
- Add Changelog.

Contributing instructions now leverage the ci files, if the ci files are wrong then travis isn't building anyway so this should be a cheap way of guaranteeing everyone can get started.
Changelog may want to be backfilled at least with major changes between 2.x and last 1.x.

Edit:
I'd also like to add instructions for skipping the travis build (they provide resources for free, good to know how not to waste them), and also other common GitHub docs such as Issue and PR templates, probably a security.md also.
