### PR TITLE
Parameters not required by default

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -1,6 +1,7 @@
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/hash/conversions'
 require 'json'
+require 'byebug'
 
 module Rswag
   module Specs
@@ -33,7 +34,7 @@ module Rswag
         (operation_params + path_item_params + security_params)
           .map { |p| p['$ref'] ? resolve_parameter(p['$ref'], swagger_doc) : p }
           .uniq { |p| p[:name] }
-          .reject { |p| p[:required] == false && !example.respond_to?(p[:name]) }
+          .reject { |p| !example.respond_to?(p[:name]) }
       end
 
       def derive_security_params(metadata, swagger_doc)
@@ -54,7 +55,7 @@ module Rswag
         definitions[key]
       end
 
-      def add_verb(request, metadata) 
+      def add_verb(request, metadata)
         request[:verb] = metadata[:operation][:verb]
       end
 
@@ -104,7 +105,7 @@ module Rswag
         end
 
         # Content-Type header
-        consumes = metadata[:operation][:consumes] || swagger_doc[:consumes] 
+        consumes = metadata[:operation][:consumes] || swagger_doc[:consumes]
         if consumes
           content_type = example.respond_to?(:'Content-Type') ? example.send(:'Content-Type') : consumes.first
           tuples << [ 'Content-Type', content_type ]

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -9,7 +9,7 @@ module Rswag
       before do
         allow(config).to receive(:get_swagger_doc).and_return(swagger_doc)
       end
-      let(:config) { double('config') } 
+      let(:config) { double('config') }
       let(:swagger_doc) { {} }
       let(:example) { double('example') }
       let(:metadata) do
@@ -113,11 +113,57 @@ module Rswag
           end
         end
 
-        context 'optional parameters not provided' do
+        context 'implicit optional parameters not provided' do
+          before do
+            metadata[:operation][:parameters] = [
+              { name: 'q1', in: :query, type: :string },
+              { name: 'Api-Key', in: :header, type: :string }
+            ]
+          end
+
+          it 'builds request hash without them' do
+            expect(request[:path]).to eq('/blogs')
+            expect(request[:headers]).to eq({})
+          end
+        end
+
+        context 'explicit optional parameters not provided' do
           before do
             metadata[:operation][:parameters] = [
               { name: 'q1', in: :query, type: :string, required: false },
               { name: 'Api-Key', in: :header, type: :string, required: false }
+            ]
+          end
+
+          it 'builds request hash without them' do
+            expect(request[:path]).to eq('/blogs')
+            expect(request[:headers]).to eq({})
+          end
+        end
+
+        context 'optional parameters provided' do
+          before do
+            metadata[:operation][:parameters] = [
+              { name: 'q1', in: :query, type: :string },
+              { name: 'Api-Key', in: :header, type: :string }
+            ]
+            allow(example).to receive(:q1).and_return('foo')
+            allow(example).to receive(:'Api-Key').and_return('bar')
+          end
+
+          it 'builds request hash without them' do
+            expect(request[:path]).to eq('/blogs?q1=foo')
+            expect(request[:headers]).to eq({ 'Api-Key' => 'bar' })
+          end
+        end
+
+        # This is the expected outcome, in order to test application-level
+        # responses when required params are not defined
+        context 'required parameters not provided' do
+          before do
+            metadata[:operation][:parameters] = [
+              { name: 'q1', in: :query, type: :string, required: true },
+              { name: 'Api-Key', in: :header, type: :string, required: true }
             ]
           end
 


### PR DESCRIPTION
The Swagger (2.0) spec states that without specifying the required property, parameters are not required by default. Rswag throws a NoMethodError if a parameter is not explicitly required and also not defined in an example. In effect it forces non-required parameters to be defined before the spec runs.

I shamelessly took @domaindrivendev's solution from [this comment](https://github.com/rswag/rswag/pull/126#issuecomment-432290716) (which I tested and find to be the best solution), wrote some tests, an created this PR in the hope we can get this merged and avoid the confusion this bug causes, in the future.

To note, this solution means it's up to the application developer to test for missing required parameters via their API. But, parameters should only be required if the API responds with an error, anyway. (see [this issue](https://github.com/rswag/rswag/issues/145))