### PR TITLE
add support reusing responses

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -58,6 +58,10 @@ module Rswag
         metadata[:response][:schema] = value
       end
 
+      def ref(value)
+        metadata[:response][:$ref] = value
+      end
+
       def header(name, attributes)
         metadata[:response][:headers] ||= {}
         metadata[:response][:headers][name] = attributes

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -150,6 +150,15 @@ module Rswag
         end
       end
 
+      describe '#ref(value)' do
+        before { subject.ref('#/responses/Unauthorized') }
+        let(:api_metadata) { { response: {} } }
+
+        it "adds to the 'response' metadata" do
+          expect(api_metadata[:response][:$ref]).to match('#/responses/Unauthorized')
+        end
+      end
+
       describe '#header(name, attributes)' do
         before { subject.header('Date', type: 'string') }
         let(:api_metadata) { { response: {} } }


### PR DESCRIPTION
Hi all,

First of all, thanks for creating this awesome gem and sorry for my bad English.

I tried to use [**Reusing Responses**](https://swagger.io/docs/specification/2-0/describing-responses/), but it seems this current version does not support it.

I tried to check your code and couldn't figure it out, so if the current version already supports, please show me how to do it.

Here the example config:

I define responses in _swagger_helper_ like this

```
{
  responses: {
    Unauthorized: {
      description: 'Unauthorized',
      schema: {
        '$ref': '#/definitions/Error'
      }
    }
  }
}
```

I want to generate config response for my api endpoint in _swagger.json_ like this

```
"401": {
  "description": "",
  "$ref": "#/responses/Unauthorized"
}
```

With this **ref** method, I will do like this

```
response '401', '' do
  ref('#/responses/Unauthorized')
  run_test!
end
```