### PR TITLE
Parameterize the pattern for test locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,15 @@ end
 
 __NOTE__: If you do change this, you'll also need to update the rswag-api.rb initializer (assuming you're using rswag-api). More on this later.
 
+### Input Location for Rspec Tests ###
+
+By default, rswag will search for integration tests in _spec/requests_, _spec/api_ and _spec/integration_. If you want to use tests from other locations, provide the PATTERN argument to rake:
+
+```ruby
+# search for tests in spec/swagger
+rake rswag:specs:swaggerize PATTERN="spec/swagger/**/*_spec.rb"
+```
+
 ### Referenced Parameters and Schema Definitions ###
 
 Swagger allows you to describe JSON structures inline with your operation descriptions OR as referenced globals. For example, you might have a standard response structure for all failed operations. Rather than repeating the schema in every operation spec, you can define it globally and provide a reference to it in each spec:

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -5,7 +5,10 @@ namespace :rswag do
 
     desc 'Generate Swagger JSON files from integration specs'
     RSpec::Core::RakeTask.new('swaggerize') do |t|
-      t.pattern = 'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
+      t.pattern = ENV.fetch(
+        'PATTERN',
+        'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
+      )
 
       # NOTE: rspec 2.x support
       if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.swagger_dry_run
@@ -18,4 +21,3 @@ namespace :rswag do
 end
 
 task :rswag => ['rswag:specs:swaggerize']
-


### PR DESCRIPTION
This commit allows users to specify search patterns when finding tests to
swaggerize. Omitting the pattern parameter makes rswag search with the default
patterns.

A typical usecase for this feature is when you already have a test suite set up
and you want to use rswag for generating swagger docs rather than high-coverage
testing.

Usage:

rake rswag:specs:swaggerize PATTERN='/your_path..'