### PR TITLE
Add ENV var to configure dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,14 +452,15 @@ after do |example|
   example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
 end
 ```
-You need to disable --dry-run option for Rspec > 3
+You need to disable `--dry-run` option for Rspec > 3. You can do one of the following:
 
-Add to application.rb:
-```ruby
-RSpec.configure do |config|
-  config.swagger_dry_run = false
-end
-```
+- use environment varible `SWAGGER_DRY_RUN` set to `1` during generation command
+- or add the following to your `application.rb`:
+  ```ruby
+  RSpec.configure do |config|
+    config.swagger_dry_run = false
+  end
+  ```
 
 ### Running tests without documenting ###
 

--- a/rswag-specs/lib/rswag/specs/configuration.rb
+++ b/rswag-specs/lib/rswag/specs/configuration.rb
@@ -26,9 +26,11 @@ module Rswag
       end
 
       def swagger_dry_run
-        @swagger_dry_run ||= begin
-          @rspec_config.swagger_dry_run.nil? || @rspec_config.swagger_dry_run
+        return @swagger_dry_run if defined? @swagger_dry_run
+        if ENV.key?('SWAGGER_DRY_RUN')
+          @rspec_config.swagger_dry_run = ENV['SWAGGER_DRY_RUN'] == '1'
         end
+        @swagger_dry_run = @rspec_config.swagger_dry_run.nil? || @rspec_config.swagger_dry_run
       end
 
       def swagger_format


### PR DESCRIPTION
During integration with rswag, we noticed that we need to set dry run very early and suggestion is to put it in `application.rb`. We did not really want to add specs related code to production code. So we came up with this solution. What do you think?