### PR TITLE
 allow xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,13 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
             let(:blog) { { title: 'foo', content: 'bar' } }
             run_test!
           end
-
+          
+          response '201', 'blog created with xml' do
+            let(:"CONTENT_TYPE"){"application/xml"}
+            let(:blog) { "<blog><title>foo</title><content>bar</content></blog>" } }
+            run_test!
+          end
+          
           response '422', 'invalid request' do
             let(:blog) { { title: 'foo' } }
             run_test!

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -132,6 +132,8 @@ module Rswag
 
         if [ 'application/x-www-form-urlencoded', 'multipart/form-data' ].include?(content_type)
           request[:payload] = build_form_payload(parameters, example)
+        elsif [ 'application/xml', 'text/xml' ].include?(content_type)
+          request[:payload] = build_form_payload(parameters, example)        
         else
           request[:payload] = build_json_payload(parameters, example)
         end
@@ -151,6 +153,11 @@ module Rswag
       def build_json_payload(parameters, example)
         body_param = parameters.select { |p| p[:in] == :body }.first
         body_param ? example.send(body_param[:name]).to_json : nil
+      end
+            
+      def build_xml_payload(parameters, example)
+        body_param = parameters.select { |p| p[:in] == :body }.first
+        body_param ? example.send(body_param[:name]) : nil
       end
     end
   end

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -133,7 +133,7 @@ module Rswag
         if [ 'application/x-www-form-urlencoded', 'multipart/form-data' ].include?(content_type)
           request[:payload] = build_form_payload(parameters, example)
         elsif [ 'application/xml', 'text/xml' ].include?(content_type)
-          request[:payload] = build_form_payload(parameters, example)        
+          request[:payload] = build_xml_payload(parameters, example)        
         else
           request[:payload] = build_json_payload(parameters, example)
         end


### PR DESCRIPTION
XML can't be sent in though the request body, it's converted into a JSON xml string.

Change is to allow application/xml as a content type