### PR TITLE
fix README.md: dry_run goes into test.rb, not application.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ end
 ```
 You need to disable --dry-run option for Rspec > 3
 
-Add to application.rb:
+Add to config/environments/test.rb:
 ```ruby
 RSpec.configure do |config|
   config.swagger_dry_run = false


### PR DESCRIPTION
adding `RSpec.configure` to `application.rb` can lead to problems in production, where rspec may not be present.  The error message I got when using  `application.rb` and deploying to heroku was:

```
remote:  !     Could not detect rake tasks
remote:  !     ensure you can run `$ bundle exec rake -P` against your app
remote:  !     and using the production group of your Gemfile.
remote:  !     rake aborted!
remote:  !     NameError: uninitialized constant RSpec
...
remote:  !     /tmp/build_1c../config/application.rb:23:in `<top (required)>'
```


Using  `config/environments/test.rb` instead avoids these problems.
