### PR TITLE
request factory / add support of hash as query string params

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -75,19 +75,27 @@ module Rswag
 
       def build_query_string_part(param, value)
         name = param[:name]
-        return "#{name}=#{value.to_s}" unless param[:type].to_sym == :array
 
-        case param[:collectionFormat]
-        when :ssv
-          "#{name}=#{value.join(' ')}"
-        when :tsv
-          "#{name}=#{value.join('\t')}"
-        when :pipes
-          "#{name}=#{value.join('|')}"
-        when :multi
-          value.map { |v| "#{name}=#{v}" }.join('&')
+        case param[:type].to_sym 
+        when :array
+          case param[:collectionFormat].to_sym 
+          when :ssv
+            "#{name}=#{value.join(' ')}"
+          when :tsv
+            "#{name}=#{value.join('\t')}"
+          when :pipes
+            "#{name}=#{value.join('|')}"
+          when :multi
+            value.map { |v| "#{name}=#{v}" }.join('&')
+          else
+            "#{name}=#{value.join(',')}" # csv is default
+          end
+        when :hash
+          query_hash = {}
+          query_hash[name] = value
+          query_hash.to_query
         else
-          "#{name}=#{value.join(',')}" # csv is default
+          "#{name}=#{value.to_s}"
         end
       end
 


### PR DESCRIPTION
Hi, 

I've added support of hash to query parameters in the request factory.

With the following parameter definition: 

```
parameter name: :vFilter, :in => :query, :type => :hash, :required => false, schema: {
        '$ref': '#/definitions/....'
      }
```

With the following spec configuration: 
```
describe 'with risk filter' do
  (...)
  let(:vFilter) { {risks: ["FooBar"]} }
  run_test!
```

Will generate the following query parameters:  `"vFilter%5Brisks%5D%5B%5D=FooBar"`

Sorry, but I do not have the time to write new tests.
Best regards.