### PR TITLE
add output for swaggerize command by inheriting thhe base text formatter

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -1,9 +1,10 @@
 require 'active_support/core_ext/hash/deep_merge'
+require 'rspec/core/formatters/base_text_formatter'
 require 'swagger_helper'
 
 module Rswag
   module Specs
-    class SwaggerFormatter
+    class SwaggerFormatter < ::RSpec::Core::Formatters::BaseTextFormatter
 
       # NOTE: rspec 2.x support
       if RSPEC_VERSION > 2


### PR DESCRIPTION
**Problem**
If the Swaggerize command fails for any reason, there is no output; task exits with exit(1) unexplained.

**Solution**
Make our RSpec formatter output basic output, 


**Before**
```bash
$ RAILS_ENV=test rails rswag
Generating Swagger docs ...
Swagger doc generated at /Users/me/source/my_app/swagger/v1/swagger.json
```
**After**
```bash
$ RAILS_ENV=test rails rswag
Generating Swagger docs ...
Swagger doc generated at /Users/me/source/my_app/swagger/v1/swagger.json

Finished in 3.1 seconds (files took 4.12 seconds to load)
13 examples, 0 failures
```
or 
```
$ RAILS_ENV=test rails rswag
Generating Swagger docs ...
Swagger doc generated at /Users/me/source/rswag/test-app/swagger/v1/swagger.json

Failures:

  1) Blogs API /blogs post invalid request returns a 422 response
     Failure/Error: @blog = Blog.create(params.require(:blog).permit(:title, :content))

     ActionController::ParameterMissing:
       param is missing or the value is empty: blog
     # ./app/controllers/blogs_controller.rb:7:in `create'
     # /Users/me/source/rswag/rswag-specs/lib/rswag/specs/example_helpers.rb:20:in `submit_request'
     # /Users/me/source/rswag/rswag-specs/lib/rswag/specs/example_group_helpers.rb:221:in `block in run_test!'

Finished in 0.13813 seconds (files took 1.52 seconds to load)
6 examples, 1 failure

Failed examples:

rspec ./spec/integration/blogs_spec.rb:22 # Blogs API /blogs post invalid request returns a 422 response
```
**TODO**
- [ ] Add a test

**References**
This is available in both RSpec 2.x and 3.x so no need for compatibility.
https://github.com/rspec/rspec-core/blob/2-99-maintenance/lib/rspec/core/formatters/base_formatter.rb