### PR TITLE
Fix route_parser each_with_object call

### DIFF
--- a/rswag-specs/lib/rswag/route_parser.rb
+++ b/rswag-specs/lib/rswag/route_parser.rb
@@ -11,7 +11,7 @@ module Rswag
     def routes
       ::Rails.application.routes.routes.select do |route|
         route.defaults[:controller] == controller
-      end.each_with_object({}) do |tree, route|
+      end.each_with_object({}) do |route, tree|
         path = path_from(route)
         verb = verb_from(route)
         tree[path] ||= { params: params_from(route), actions: {} }


### PR DESCRIPTION
When I tried to generate a new spec, I noticed the `each_with_object` call in `route_parser.rb` was mixed up.