### PR TITLE
Allow to use different securities per response block

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -15,10 +15,14 @@ module Rswag
         end
       end
 
-      [:operationId, :deprecated, :security].each do |attr_name|
+      [:operationId, :deprecated].each do |attr_name|
         define_method(attr_name) do |value|
           metadata[:operation][attr_name] = value
         end
+      end
+
+      def security(value)
+        metadata[:operation] = metadata[:operation].merge(security: value)
       end
 
       # NOTE: 'description' requires special treatment because ExampleGroup already

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -35,7 +35,7 @@ module Rswag
         end
       end
 
-      describe '#tags|description|operationId|consumes|produces|schemes|deprecated|security(value)' do
+      describe '#tags|description|operationId|consumes|produces|schemes|deprecated(value)' do
         before do
           subject.tags('Blogs', 'Admin')
           subject.description('Some description')
@@ -44,7 +44,6 @@ module Rswag
           subject.produces('application/json', 'application/xml')
           subject.schemes('http', 'https')
           subject.deprecated(true)
-          subject.security(api_key: [])
         end
         let(:api_metadata) { { operation: {} } }
 
@@ -57,6 +56,17 @@ module Rswag
             produces: ['application/json', 'application/xml'],
             schemes: ['http', 'https'],
             deprecated: true,
+          )
+        end
+      end
+
+      describe '#security(value)' do
+        let(:api_metadata) { { operation: {} } }
+
+        it "adds to the 'operation' metadata" do
+          expect { subject.security(api_key: []) }.to change { api_metadata[:operation].object_id }
+
+          expect(api_metadata[:operation]).to match(
             security: { api_key: [] }
           )
         end

--- a/test-app/app/controllers/auth_tests_controller.rb
+++ b/test-app/app/controllers/auth_tests_controller.rb
@@ -18,6 +18,12 @@ class AuthTestsController < ApplicationController
     head :no_content
   end
 
+  # POST /auth-tests/basic-and-no-api-key
+  def basic_and_no_api_key
+    return head :unauthorized unless authenticate_basic and not authenticate_api_key
+    head :no_content
+  end
+
   private
 
   def authenticate_basic

--- a/test-app/config/routes.rb
+++ b/test-app/config/routes.rb
@@ -8,6 +8,7 @@ TestApp::Application.routes.draw do
   post 'auth-tests/basic', to: 'auth_tests#basic'
   post 'auth-tests/api-key', to: 'auth_tests#api_key'
   post 'auth-tests/basic-and-api-key', to: 'auth_tests#basic_and_api_key'
+  post 'auth-tests/basic-and-no-api-key', to: 'auth_tests#basic_and_no_api_key'
 
   mount  Rswag::Api::Engine => 'api-docs'
   mount  Rswag::Ui::Engine => 'api-docs'

--- a/test-app/spec/integration/auth_tests_spec.rb
+++ b/test-app/spec/integration/auth_tests_spec.rb
@@ -58,4 +58,24 @@ RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' 
       end
     end
   end
+
+  path '/auth-tests/basic-and-no-api-key' do
+    post 'Authenticates with basic auth and no api key' do
+      tags 'Auth Tests'
+      operationId 'testBasicAndApiKey'
+
+      response '401', 'Invalid credentials' do
+        security [{ basic_auth: [], api_key: [] }]
+        let(:Authorization) { "Basic #{::Base64.strict_encode64('jsmith:jspass')}" }
+        let(:api_key) { 'foobar' }
+        run_test!
+      end
+
+      response '204', 'Valid basic auth' do
+        security [{ basic_auth: [] }]
+        let(:Authorization) { "Basic #{::Base64.strict_encode64('jsmith:jspass')}" }
+        run_test!
+      end
+    end
+  end
 end

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -92,6 +92,34 @@
         }
       }
     },
+    "/auth-tests/basic-and-no-api-key": {
+      "post": {
+        "summary": "Authenticates with basic auth and no api key",
+        "tags": [
+          "Auth Tests"
+        ],
+        "operationId": "testBasicAndApiKey",
+        "security": [
+          {
+            "basic_auth": [
+
+            ]
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Invalid credentials",
+            "content": {
+            }
+          },
+          "204": {
+            "description": "Valid basic auth",
+            "content": {
+            }
+          }
+        }
+      }
+    },
     "/blogs": {
       "post": {
         "summary": "Creates a blog",


### PR DESCRIPTION
Imagine that you want to test a specific endpoint where the you must not
send the credentials, like a sign in or recovery password endpoint where
you must not be logged in.

The previous implementation was leaking the security definition to
unrelated responses due to the RSpec metadata design.

This is still true for other definitions but the most important one to
not leak is just the security.