### PR TITLE
[Fix] move examples inside mime_type

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -70,7 +70,7 @@ module Rswag
       # being invoked with no params to avoid overriding 'examples' method of
       # rspec-core ExampleGroup
       def examples(examples = nil)
-        return super() if example.nil?
+        return super() if examples.nil?
 
         metadata[:response][:examples] = examples
       end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -69,10 +69,16 @@ module Rswag
       # NOTE: Similar to 'description', 'examples' need to handle the case when
       # being invoked with no params to avoid overriding 'examples' method of
       # rspec-core ExampleGroup
-      def examples(example = nil)
+      def examples(examples = nil)
         return super() if example.nil?
 
-        metadata[:response][:examples] = example
+        metadata[:response][:examples] = examples
+      end
+
+      def example(example = nil)
+        return super() if example.nil?
+
+        metadata[:response][:example] = example
       end
 
       def run_test!(&block)

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -126,16 +126,21 @@ module Rswag
         target_node = metadata[:response]
         upgrade_content!(mime_list, target_node)
         metadata[:response].delete(:schema)
+        metadata[:response].delete(:examples)
       end
 
       def upgrade_content!(mime_list, target_node)
         target_node.merge!(content: {})
         schema = target_node[:schema]
+        examples = target_node[:examples]
         return if mime_list.empty? || schema.nil?
 
         mime_list.each do |mime_type|
           # TODO upgrade to have content-type specific schema
-          target_node[:content][mime_type] = { schema: schema }
+          target_node[:content][mime_type] = {
+            schema: schema,
+            examples: examples,
+          }
         end
       end
 

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -181,7 +181,7 @@ module Rswag
       def upgrade_servers!(swagger_doc)
         return unless swagger_doc[:servers].nil? && swagger_doc.key?(:schemes)
 
-        #ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: schemes, host, and basePath are replaced in OpenAPI3! Rename to array of servers[{url}] (in swagger_helper.rb)')
+        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: schemes, host, and basePath are replaced in OpenAPI3! Rename to array of servers[{url}] (in swagger_helper.rb)')
 
         swagger_doc[:servers] = { urls: [] }
         swagger_doc[:schemes].each do |scheme|
@@ -201,14 +201,14 @@ module Rswag
         schemes.each do |name, v|
           next unless v.key?(:flow)
 
-          #ActiveSupport::Deprecation.warn("Rswag::Specs: WARNING: securityDefinitions flow is replaced in OpenAPI3! Rename to components/securitySchemes/#{name}/flows[] (in swagger_helper.rb)")
+          ActiveSupport::Deprecation.warn("Rswag::Specs: WARNING: securityDefinitions flow is replaced in OpenAPI3! Rename to components/securitySchemes/#{name}/flows[] (in swagger_helper.rb)")
           flow = swagger_doc[:components][:securitySchemes][name].delete(:flow).to_s
           if flow == 'accessCode'
-            #ActiveSupport::Deprecation.warn("Rswag::Specs: WARNING: securityDefinitions accessCode is replaced in OpenAPI3! Rename to clientCredentials (in swagger_helper.rb)")
+            ActiveSupport::Deprecation.warn("Rswag::Specs: WARNING: securityDefinitions accessCode is replaced in OpenAPI3! Rename to clientCredentials (in swagger_helper.rb)")
             flow = 'authorizationCode'
           end
           if flow == 'application'
-            #ActiveSupport::Deprecation.warn("Rswag::Specs: WARNING: securityDefinitions application is replaced in OpenAPI3! Rename to authorizationCode (in swagger_helper.rb)")
+            ActiveSupport::Deprecation.warn("Rswag::Specs: WARNING: securityDefinitions application is replaced in OpenAPI3! Rename to authorizationCode (in swagger_helper.rb)")
             flow = 'clientCredentials'
           end
           flow_elements = swagger_doc[:components][:securitySchemes][name].except(:type).each_with_object({}) do |(k, _v), a|

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -146,7 +146,18 @@ module Rswag
         if example
           set_mime_list_contents!(target_node, mime_list, :example, example)
         elsif examples
-          set_mime_list_contents!(target_node, mime_list, :examples, examples)
+          #check if examples contains mime_types from swagger2.0 response example style
+          non_mime_type_examples = {}
+          examples.each do |key, value|
+            if mime_list.include? key
+              set_mime_type_content!(target_node, key, :example, value)
+            else
+              non_mime_type_examples[key] = value
+            end
+          end
+          unless non_mime_type_examples.empty?
+            set_mime_list_contents!(target_node, mime_list, :examples, non_mime_type_examples)
+          end
         end
       end
 

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -137,10 +137,9 @@ module Rswag
 
         mime_list.each do |mime_type|
           # TODO upgrade to have content-type specific schema
-          target_node[:content][mime_type] = {
-            schema: schema,
-            examples: examples,
-          }
+          target_node[:content][mime_type] = {}
+          target_node[:content][mime_type][:schema] = schema if schema
+          target_node[:content][mime_type][:examples] = examples if examples
         end
       end
 

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -154,6 +154,25 @@ module Rswag
           expect(api_metadata[:response][:examples]).to eq(json_example)
         end
       end
+
+      describe '#example(example)' do
+        let(:json_example) do
+          {
+            'application/json' => {
+              foo: 'bar'
+            }
+          }
+        end
+        let(:api_metadata) { { response: {} } }
+
+        before do
+          subject.example(json_example)
+        end
+
+        it "adds to the 'response example' metadata" do
+          expect(api_metadata[:response][:example]).to eq(json_example)
+        end
+      end
     end
   end
 end

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -168,6 +168,77 @@ module Rswag
             )
           end
 
+          context "with example and examples" do
+            let(:api_metadata) do
+              {
+                path_item: { template: '/blogs', parameters: [{ type: :string }] },
+                operation: { verb: :post, summary: 'Creates a blog', parameters: [{ type: :string }] },
+                response: {
+                  code: '201',
+                  description: 'blog created',
+                  headers: { type: :string },
+                  schema: { '$ref' => '#/definitions/blog' },
+                  example: {
+                    'data' => {
+                      'id' => '1',
+                      'type' => 'record'
+                    }
+                  },
+                  examples: {
+                    one: {
+                      value: {
+                        'data' => {
+                          'id' => '1',
+                          'type' => 'record'
+                        }
+                      }
+                    },
+                    two: {
+                      value: {
+                        'data' => {
+                          'id' => '2',
+                          'type' => 'record'
+                        }
+                      }
+                    }
+                  }
+                },
+                document: document
+              }
+            end
+
+            it 'adds params to mime_type' do
+              expect(swagger_doc.slice(:paths)).to match(
+                paths: {
+                  '/blogs' => {
+                    parameters: [{ schema: { type: :string } }],
+                    post: {
+                      parameters: [{ schema: { type: :string } }],
+                      summary: 'Creates a blog',
+                      responses: {
+                        '201' => {
+                          content: {
+                            'application/vnd.my_mime' => {
+                              schema: { '$ref' => '#/definitions/blog' },
+                              example: { "data" => {"id" => "1", "type" => "record" }}
+                            },
+                            'application/json' => {
+                              schema: { '$ref' => '#/definitions/blog' },
+                              example: { "data" => {"id" => "1", "type" => "record" }}
+                            }
+                          },
+                          description: 'blog created',
+                          headers: { schema: { type: :string } }
+                        }
+                      }
+                    }
+                  }
+                }
+              )
+            end
+
+          end
+
           context "with examples" do
             let(:api_metadata) do
               {
@@ -216,10 +287,10 @@ module Rswag
                               schema: { '$ref' => '#/definitions/blog' },
                               examples: {
                                 one: {
-                                  value: {"data"=>{"id"=>"1", "type"=>"record"}}
+                                  value: { "data" => {"id" => "1", "type" => "record"} }
                                 },
                                 two: {
-                                  value: {"data"=>{"id"=>"2", "type"=>"record"}}
+                                  value: { "data" => {"id" => "2", "type" => "record"} }
                                 }
                               }
                             },
@@ -227,10 +298,10 @@ module Rswag
                               schema: { '$ref' => '#/definitions/blog' },
                               examples: {
                                 one: {
-                                  value: {"data"=>{"id"=>"1", "type"=>"record"}}
+                                  value: { "data" => {"id" => "1", "type" => "record"} }
                                 },
                                 two: {
-                                  value: {"data"=>{"id"=>"2", "type"=>"record"}}
+                                  value: { "data" => {"id" => "2", "type" => "record"} }
                                 }
                               }
                             }

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -167,6 +167,85 @@ module Rswag
               }
             )
           end
+
+          context "with examples" do
+            let(:api_metadata) do
+              {
+                path_item: { template: '/blogs', parameters: [{ type: :string }] },
+                operation: { verb: :post, summary: 'Creates a blog', parameters: [{ type: :string }] },
+                response: {
+                  code: '201',
+                  description: 'blog created',
+                  headers: { type: :string },
+                  schema: { '$ref' => '#/definitions/blog' },
+                  examples: {
+                    one: {
+                      value: {
+                        'data' => {
+                          'id' => '1',
+                          'type' => 'record'
+                        }
+                      }
+                    },
+                    two: {
+                      value: {
+                        'data' => {
+                          'id' => '2',
+                          'type' => 'record'
+                        }
+                      }
+                    }
+                  }
+                },
+                document: document
+              }
+            end
+
+            it 'adds params to mime_type' do
+              expect(swagger_doc.slice(:paths)).to match(
+                paths: {
+                  '/blogs' => {
+                    parameters: [{ schema: { type: :string } }],
+                    post: {
+                      parameters: [{ schema: { type: :string } }],
+                      summary: 'Creates a blog',
+                      responses: {
+                        '201' => {
+                          content: {
+                            'application/vnd.my_mime' => {
+                              schema: { '$ref' => '#/definitions/blog' },
+                              examples: {
+                                one: {
+                                  value: {"data"=>{"id"=>"1", "type"=>"record"}}
+                                },
+                                two: {
+                                  value: {"data"=>{"id"=>"2", "type"=>"record"}}
+                                }
+                              }
+                            },
+                            'application/json' => {
+                              schema: { '$ref' => '#/definitions/blog' },
+                              examples: {
+                                one: {
+                                  value: {"data"=>{"id"=>"1", "type"=>"record"}}
+                                },
+                                two: {
+                                  value: {"data"=>{"id"=>"2", "type"=>"record"}}
+                                }
+                              }
+                            }
+                          },
+                          description: 'blog created',
+                          headers: { schema: { type: :string } }
+                        }
+                      }
+                    }
+                  }
+                }
+              )
+            end
+
+          end
         end
       end
 

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -235,18 +235,16 @@
                 "type": "string"
               }
             },
-            "examples": {
-              "application/json": {
-                "id": 1,
-                "title": "Hello world!",
-                "content": "Hello world and hello universe. Thank you all very much!!!",
-                "thumbnail": "thumbnail.png"
-              }
-            },
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/definitions/blog"
+                },
+                "example": {
+                  "id": 1,
+                  "title": "Hello world!",
+                  "content": "Hello world and hello universe. Thank you all very much!!!",
+                  "thumbnail": "thumbnail.png"
                 }
               }
             }


### PR DESCRIPTION
**Fixes**
Currently for openapi: 3.0.1, the examples are not being rendered because the 
the key `examples` was moved into inside mime_type.

This PR also adds example method.
This is only available in openapi: 3.0.1.