### PR TITLE
Allow multiple response examples to be defined per status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ To enable examples generation from responses add callback above run_test! like:
 
 ```
 after do |example|
-  example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+  example.example_group.example_value JSON.parse(response.body, symbolize_names: true)
 end
 ```
 

--- a/rswag-specs/lib/generators/rspec/templates/spec.rb
+++ b/rswag-specs/lib/generators/rspec/templates/spec.rb
@@ -19,7 +19,7 @@ RSpec.describe '<%= controller_path %>', type: :request do
 <%      end -%>
 
         after do |example|
-          example.metadata[:response][:examples] = { 'application/json' => JSON.parse(response.body, symbolize_names: true) }
+          example.example_group.example_value JSON.parse(response.body, symbolize_names: true)
         end
         run_test!
       end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/string/inflections'
+
 module Rswag
   module Specs
     module ExampleGroupHelpers
@@ -52,8 +54,19 @@ module Rswag
       end
 
       def response(code, description, metadata = {}, &block)
-        metadata[:response] = { code: code, description: description }
+        metadata[:response] = { code: code, description: description, examples: {} }
         context(description, metadata, &block)
+      end
+
+      def example_context(description, metadata = {}, &block)
+        context(description, metadata.merge(skip_formatter: true), &block)
+      end
+
+      def example_value(value)
+        metadata[:response][:examples][metadata[:description].parameterize separator: '_'] = {
+          summary: metadata[:description],
+          value: value
+        }
       end
 
       def schema(value)

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -111,7 +111,7 @@ module Rswag
 
         it "delegates to 'context' with 'response' metadata" do
           expect(subject).to have_received(:context).with(
-            'success', response: { code: '201', description: 'success' }
+            'success', response: { code: '201', description: 'success', examples: {} }
           )
         end
       end


### PR DESCRIPTION
For example:

```ruby
  after do |example|
    example.example_group.example_value JSON.parse(response.body, symbolize_names: true) if response
  end

  response 422, 'invalid request' do
    example_context 'name is missing'
      let(:password) { 'secret' }
      run_test!
    end

    example_context 'password is missing' do
      let(:name) { 'bobby' }
      run_test!
    end

    example_context 'bad content type' do
      example_value(
        error: 'bad content type'
      )
    end
  end
```

Annoyingly you still need a dummy RSpec example to include a static example value on its own but that's a limitation of RSwag's design.

I really really want to be able to have multiple media types per response here and the lack of support for that is killing me. I tried to see whether there was a straightforward way to add it but didn't get anywhere. It's a shame as this worked in the openapi-rswag fork. Trying to shoehorn V3 support into V2 syntax doesn't seem like the best way to go.