### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,15 @@ config.swagger_docs = {
             thumbnail: { type: 'string', nullable: true }
           },
           required: %w[id title]
+        },
+        new_blog: {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            content: { type: 'string', nullable: true },
+            thumbnail: { type: 'string', format: 'binary', nullable: true }
+          },
+          required: %w[title]
         }
       }
     }
@@ -528,6 +537,8 @@ describe 'Blogs API' do
   path '/blogs' do
 
     post 'Creates a blog' do
+
+      parameter name: :new_blog, in: :body, schema: { '$ref' => '#/components/schemas/new_blog' }
 
       response 422, 'invalid request' do
         schema '$ref' => '#/components/schemas/errors_object'


### PR DESCRIPTION
Update **Referenced Parameters and Schema Definitions** example to use referenced parameters.

The existing README isn't exactly clear on how to use references for parameters such as requestBody for a post request. Currently, you can really only infer it from the `oneOf` example, or dive into the test-app examples.