### PR TITLE
[Feature] Custom basePath on specific specs

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -102,7 +102,7 @@ module Rswag
       end
 
       def add_path(request, metadata, swagger_doc, parameters, example)
-        template = (swagger_doc[:basePath] || '') + metadata[:path_item][:template]
+        template = (metadata[:base_path] || swagger_doc[:basePath] || '') + metadata[:path_item][:template]
 
         request[:path] = template.tap do |path_template|
           parameters.select { |p| p[:in] == :path }.each do |p|

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -42,6 +42,16 @@ module Rswag
           it 'builds the path from example values' do
             expect(request[:path]).to eq('/blogs/1/comments/2')
           end
+
+          context "'path' parameters with custom base_path" do
+            before do
+              metadata[:base_path] = '/api'
+            end
+
+            it 'should use custom base_path from metadata' do
+              expect(request[:path]).to eq('/api/blogs/1/comments/2')
+            end
+          end
         end
 
         context "'query' parameters" do
@@ -173,9 +183,9 @@ module Rswag
 
             it 'sets payload to hash of names and example values' do
               expect(request[:payload]).to eq(
-                'f1' => 'foo blah',
-                'f2' => 'bar blah'
-              )
+                                             'f1' => 'foo blah',
+                                             'f2' => 'bar blah'
+                                           )
             end
           end
         end
@@ -240,7 +250,7 @@ module Rswag
             it 'warns the user to upgrade' do
               expect(request[:headers]).to eq('HTTP_AUTHORIZATION' => 'Basic foobar')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                .with('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
+                                                      .with('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
               expect(swagger_doc[:components]).to have_key(:securitySchemes)
             end
           end
@@ -367,9 +377,9 @@ module Rswag
             it 'warns the user to upgrade' do
               expect(request[:path]).to eq('/blogs?q1=foo')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                .with('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
+                                                      .with('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                .with('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
+                                                      .with('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
             end
           end
         end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -183,9 +183,9 @@ module Rswag
 
             it 'sets payload to hash of names and example values' do
               expect(request[:payload]).to eq(
-                                             'f1' => 'foo blah',
-                                             'f2' => 'bar blah'
-                                           )
+                'f1' => 'foo blah',
+                'f2' => 'bar blah'
+              )
             end
           end
         end
@@ -250,7 +250,7 @@ module Rswag
             it 'warns the user to upgrade' do
               expect(request[:headers]).to eq('HTTP_AUTHORIZATION' => 'Basic foobar')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                                                      .with('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
+                .with('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
               expect(swagger_doc[:components]).to have_key(:securitySchemes)
             end
           end
@@ -377,9 +377,9 @@ module Rswag
             it 'warns the user to upgrade' do
               expect(request[:path]).to eq('/blogs?q1=foo')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                                                      .with('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
+                .with('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                                                      .with('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
+                 .with('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
             end
           end
         end


### PR DESCRIPTION
Allow to provide custom basePath on ``describe`` and ``path`` blocks.
Usage
```
describe 'User sessions API', base_path: '/api' do

end
```
and at path block
```
path '/users', base_path: '/api' do

end
```
