### PR TITLE
Allow for '#/component/responses/' $ref in specs

### DIFF
--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -62,7 +62,19 @@ module Rswag
             swagger_doc.slice(:definitions)
           else
             components = swagger_doc[:components] || {}
-            { components: { schemas: components[:schemas] } }
+            {
+              components: {
+                schemas: components[:schemas],
+                parameters: components[:parameters],
+                securitySchemes: components[:securitySchemes],
+                requestBodies: components[:requestBodies],
+                responses: components[:responses],
+                headers: components[:headers],
+                examples: components[:examples],
+                links: components[:links],
+                callbacks: components[:callbacks]
+              }
+            }
           end
         end
       end

--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -65,14 +65,7 @@ module Rswag
             {
               components: {
                 schemas: components[:schemas],
-                parameters: components[:parameters],
-                securitySchemes: components[:securitySchemes],
-                requestBodies: components[:requestBodies],
-                responses: components[:responses],
-                headers: components[:headers],
-                examples: components[:examples],
-                links: components[:links],
-                callbacks: components[:callbacks]
+                responses: components[:responses]
               }
             }
           end

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -122,26 +122,20 @@ module Rswag
               end
 
               context 'response body matches metadata' do
-                let(:response) do
-                  OpenStruct.new(
-                    code: '400',
-                    headers: { 'X-Rate-Limit-Limit' => '10' },
-                    body: '{"errors": ["Some error"]}'
-                  )
+                before do
+                  response[:code] = '400'
+                  response[:body] = '{"errors": ["Some error"]}'
                 end
 
                 it { expect { call }.to_not raise_error(/Expected response body/) }
               end
 
               context 'response body differs from metadata' do
-                let(:response) do
-                  OpenStruct.new(
-                    code: '400',
-                    headers: { 'X-Rate-Limit-Limit' => '10' },
-                    body: '{"errors":"Some single error"}'
-                  )
-
+                before do
+                  response[:code] = '400'
+                  response[:body] = '{"errors":"Some single error"}'
                 end
+
                 it { expect { call }.to raise_error(/Expected response body/) }
               end
             end

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rswag/specs/response_validator'
-require 'pry'
+
 module Rswag
   module Specs
     RSpec.describe ResponseValidator do


### PR DESCRIPTION
This pull request allows generic shared response schemas to be referenced in specs, for example, referencing shared error responses.

This is inline with the [OpenAPI V3 Specifications](https://swagger.io/docs/specification/components/)

Example usecase:
```ruby
# /spec/requests/controller_spec.rb
response 400, "bad request" do
  schema { "$ref" => "#/components/responses/400" }

  let(:params) { { key: 'bad-param' } }
  run_test!
end


# /components/responses/400.json
{
  "description": "Response body for a bad request",
  "type": "object",
  "properties": {
    "errors": {
      "type": "array",
      "items": {
        "type": "string",
      }
    }
  }
}
```