### PR TITLE
Allow OpenAPI 3.0 array query parameter schema

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -118,7 +118,7 @@ module Rswag
 
       def build_query_string_part(param, value)
         name = param[:name]
-        return "#{name}=#{value}" unless param[:type].to_sym == :array
+        return "#{name}=#{value}" unless param[:type].to_sym == :array || param.dig(:schema, :type)&.to_sym == :array
 
         case param[:collectionFormat]
         when :ssv


### PR DESCRIPTION
Allows for this queryString type declaration inside the `schema`

```yml
name: queryString
in: query
schema:
  type: array
  items:
    type: string
```