### PR TITLE
Use subject block

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -89,6 +89,7 @@ module Rswag
         else
           subject do |example|
             submit_request(example.metadata)
+            response
           end
 
           it "returns a #{metadata[:response][:code]} response" do |example|

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -87,11 +87,12 @@ module Rswag
             block.call(response) if block_given?
           end
         else
-          before do |example|
+          subject do |example|
             submit_request(example.metadata)
           end
 
           it "returns a #{metadata[:response][:code]} response" do |example|
+            subject
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end


### PR DESCRIPTION
(Sorry for making 2 PRs for the same thing - poor organisation on my part, will close the other shortly)

Hello! First off thanks for making such a cool project - rswag is **AWESOME** with or without this PR.

I only have one minor quibble with `rswag-specs`, and that's addressed by this PR. Please consider this PR as much a suggestion as a demand - I'm not trying to say the way rswag-specs is wrong or anything, just that I personally have a bit of a hard time working with it as it is.

### The context

I'm a big fan of the `change` matcher. I use it everywhere! But especially in `request` specs, which I treat as mini-integration tests where I want to start with the database in some state (e.g. a user exists), perform a request (`PUT /users/:that_user/password`), and verify that something happened (`that_user`'s `encrypted_password` has changed).

And I like the `subject` method in RSpec - pretty much *all* my request specs until now looked vaguely like this:

```ruby
RSpec.describe "PUT /users/:user_id/password" do
  subject do
    put "/users/#{user_id}/password", params: {
      current_password: current_password,
      new_password: new_password,
    }
    response
  end

  let!(:user) { create(:user, password: user_password) }
  let(:user_password) { "IAmCoolJeff" }
  let(:new_password) { "ThisIsCoolJeffSpeaking" }

  # i tend to have predictable names for my test vars, so "when logged in as user" here would probs
  # have a line like the below, then go on to use it to call `sign_in(user)` in a `before` block or something.
  # let(:user) { create(:user) } unless defined?(user)
  include_context "when logged in as user" do
    context "when current_password is correct" do
      let(:current_password) { "IAmCoolJeff" }

      it { expect(subject).to be_successful }
      it { expect { subject }.to change { user.reload.encrypted_password } }
    end
  end
end
```

But that doesn't work too good in this new `run_test!` paradigm I'm finding myself in - the `before` block causes the request to already have been made before my poor `it` block even runs - so I can't do my usual verification.

### The change

* In `run_test!`:
  * Swap out `before` for `subject`
  *  put `subject` at the top of the `it` block

This doesn't seem to break any of the tests for rswag-specs.
I do worry that I might have broken other peoples' tests though - if they're assuming the request will have already been made in their own `it` blocks, then perhaps their tests won't pass. Like, if they were doing something like this:

```ruby

response "200", "creates the user" do
  run_test!
  it "sets the new user's name correctly" do
    expect(User.last.name).to eq("Bob Newbie")
  end
end
```

So I can see why you might want to hold off on merging this, for sure :-)

### The example

For completeness' sake, here's my vision for how I'd write a request spec with the changes I've made to rswag-specs. I do realise that my way will cause more requests to be made to the server. If I were concerned by the amount of time my tests were taking I would implement them in a different way, but until that happens I much prefer the expressiveness and modularity of having an it block per type of assertion I'm making (e.g. I'll have a whole bunch of `expects` in the same `it` block if I'm testing the content of a hash, but I'll have one `expect` per `it` for things like checking `subject` creates a `User`, and a `LogEntry` to say that the user was created, etc.)

```ruby
RSpec.describe "API" do
  path "/users/{user_id}/password" do
    put "reset the user's password" do
      parameter name: :user_id,
                in: :path,
                type: :integer
      parameter name: :password_reset,
                in: :body,
                schema: {
                  # elided for brevity
                }

      let!(:user) { create(:user, password: user_password) }
      let(:user_password) { "IAmCoolJeff" }
      let(:new_password) { "ThisIsCoolJeffSpeaking" }

      response "200", "resets the user's password" do
        include_context "when logged in as user" do
          run_test!

          it "changes the user's password" do
            expect { subject }.to change { user.reload.encrypted_password }
          end
        end
      end

      response "400", "bad request when current_password is incorrected" do
        include_context "when logged in as user" do
          run_test!

          it "does not change the user's password" do
            expect { subject }.not_to change { user.reload.encrypted_password }
          end
        end
      end
    end
  end
end
```

Because I worry about how a PR like this might seem, I just want to make extra clear that I am not trying to tell anyone else how to write their tests - and if the rswag maintainers decide that changing `before` to `subject` is too likely to break stuff or doesn't fit their vision of how rswag-specs is intended to be used, that'll be fine. Just opening the door for a conversation! :smile: 