### PR TITLE
Clean up spec ouput

### DIFF
--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -11,6 +11,8 @@ module Rswag
       # Mock out some infrastructure
       before do
         allow(config).to receive(:swagger_root).and_return(swagger_root)
+
+        allow(ActiveSupport::Deprecation).to receive(:warn) # Silence deprecation output from specs
       end
       let(:config) { double('config') }
       let(:output) { double('output').as_null_object }

--- a/test-app/spec/integration/auth_tests_spec.rb
+++ b/test-app/spec/integration/auth_tests_spec.rb
@@ -3,6 +3,10 @@
 require 'swagger_helper'
 
 RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' do
+  before do
+    allow(ActiveSupport::Deprecation).to receive(:warn) # Silence deprecation output from specs
+  end
+
   path '/auth-tests/basic' do
     post 'Authenticates with basic auth' do
       tags 'Auth Tests'

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -3,6 +3,10 @@ require 'swagger_helper'
 RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
   let(:api_key) { 'fake_key' }
 
+  before do
+    allow(ActiveSupport::Deprecation).to receive(:warn) # Silence deprecation output from specs
+  end
+
   path '/blogs' do
     post 'Creates a blog' do
       tags 'Blogs'


### PR DESCRIPTION
Specs are currently a bit noisy with deprecation warnings, specifically specs that cover the swagger2 -> openapi3 upgrade paths.

This PR makes those specs swallow their warnings.