### PR TITLE
Allow only schema type specification on parameters

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -118,7 +118,8 @@ module Rswag
 
       def build_query_string_part(param, value)
         name = param[:name]
-        return "#{name}=#{value}" unless param[:type].to_sym == :array
+        type = param[:type] || param.dig(:schema, :type)
+        return "#{name}=#{value}" unless type.to_sym == :array
 
         case param[:collectionFormat]
         when :ssv


### PR DESCRIPTION
Fixes error on swagger generation when param type is only specified through the schema:
```
     Failure/Error: return "#{name}=#{value}" unless param[:type].to_sym == :array
     
     NoMethodError:
       undefined method `to_sym' for nil:NilClass
     # /Users/hrakotobe/.rvm/gems/ruby-2.6.6/gems/rswag-specs-2.3.1/lib/rswag/specs/request_factory.rb:121:in `build_query_string_part'
```

Sample parameter definition:
```
      parameter name: :myparam,
        in: :query,
        schema: { type: :string },
        required: false
```
