### PR TITLE
Inherit consumes from swagger schema. Addresses #320.

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -56,7 +56,7 @@ module Rswag
                 is_hash = value.is_a?(Hash)
                 if is_hash && value.dig(:parameters)
                   schema_param = value.dig(:parameters)&.find { |p| (p[:in] == :body || p[:in] == :formData) && p[:schema] }
-                  mime_list = value.dig(:consumes)
+                  mime_list = value.dig(:consumes) || doc[:consumes]
                   if value && schema_param && mime_list
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     mime_list.each do |mime|


### PR DESCRIPTION
Currently, every example should specify the `consumes` attribute. If it's missing this leads to a problem described in #320.

To avoid this we can inherit the default `consumes` attribute defined in `swagger_helper` with the ability to overwrite it in every example.