### PR TITLE
don't clobber response content

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -118,7 +118,7 @@ module Rswag
 
       def build_query_string_part(param, value)
         name = param[:name]
-        return "#{name}=#{value}" unless param[:type].to_sym == :array
+        return "#{name}=#{value}" unless param[:type]&.to_sym == :array
 
         case param[:collectionFormat]
         when :ssv

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -135,7 +135,8 @@ module Rswag
 
         mime_list.each do |mime_type|
           # TODO upgrade to have content-type specific schema
-          target_node[:content][mime_type] = { schema: schema }
+          target_node[:content][mime_type] = {} if target_node[:content][mime_type].nil?
+          target_node[:content][mime_type][:schema] = schema
         end
       end
 

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -129,7 +129,7 @@ module Rswag
       end
 
       def upgrade_content!(mime_list, target_node)
-        target_node.merge!(content: {})
+        target_node.merge!(content: {}) if target_node[:content].nil?
         schema = target_node[:schema]
         return if mime_list.empty? || schema.nil?
 


### PR DESCRIPTION
Open API 3.0.3 requires example responses to be placed under `response > content > mimetype > example`
However, current rswag deletes everything under the `content` key in order to initialize an empty object
This PR skips content empty object initialization if content is not null, in order to enable the following:

```
after do |example|
    example.metadata[:response][:content] = { 'application/json' => { example: JSON.parse(response.body, symbolize_names: true) } }
end
```