### PR TITLE
Fix response examples

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -132,9 +132,8 @@ module Rswag
       def upgrade_content!(mime_list, target_node)
         schema = target_node[:schema]
         return if mime_list.empty? || schema.nil?
-        target_node[:content] ||= {}
-        target_node.merge!(content: {})
 
+        target_node[:content] ||= {}
         mime_list.each do |mime_type|
           # TODO upgrade to have content-type specific schema
           (target_node[:content][mime_type] ||= {}).merge!(schema: schema)

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -28,10 +28,11 @@ module Rswag
           {
             path_item: { template: '/blogs', parameters: [{ type: :string }] },
             operation: { verb: :post, summary: 'Creates a blog', parameters: [{ type: :string }] },
-            response: { code: '201', description: 'blog created', headers: { type: :string }, schema: { '$ref' => '#/definitions/blog' } },
+            response: response_metadata,
             document: document
           }
         end
+        let(:response_metadata) { { code: '201', description: 'blog created', headers: { type: :string }, schema: { '$ref' => '#/definitions/blog' } } }
 
         context 'with the document tag set to false' do
           let(:swagger_doc) { { swagger: '2.0' } }
@@ -127,6 +128,47 @@ module Rswag
                 }
               }
             )
+          end
+
+          context 'with response example' do
+            let(:response_metadata) do
+              {
+                code: '201',
+                description: 'blog created',
+                headers: { type: :string },
+                content: { 'application/json' => { example: { foo: :bar } } },
+                schema: { '$ref' => '#/definitions/blog' }
+              }
+            end
+
+            it 'adds example to definition' do
+              expect(swagger_doc.slice(:paths)).to match(
+                paths: {
+                  '/blogs' => {
+                    parameters: [{ schema: { type: :string } }],
+                    post: {
+                      parameters: [{ schema: { type: :string } }],
+                      summary: 'Creates a blog',
+                      responses: {
+                        '201' => {
+                          content: {
+                            'application/vnd.my_mime' => {
+                              schema: { '$ref' => '#/definitions/blog' }
+                            },
+                            'application/json' => {
+                              schema: { '$ref' => '#/definitions/blog' },
+                              example: { foo: :bar }
+                            }
+                          },
+                          description: 'blog created',
+                          headers: { schema: { type: :string } }
+                        }
+                      }
+                    }
+                  }
+                }
+              )
+            end
           end
 
           context 'with empty content' do


### PR DESCRIPTION
## Problem
Response examples that are inside `target_node[:content]` attribute are overridden with a blank hash.

## Solution
Seems like `target_node.merge!(content: {})` line was missed during PR merge. Removing it and adding a test case.

### Checklist
- [x] Added tests
- [ ] Changelog updated