### PR TITLE
drop using #send

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_helpers.rb
@@ -7,7 +7,7 @@ module Rswag
   module Specs
     module ExampleHelpers
       def submit_request(metadata)
-        request = RequestFactory.new.build_request(metadata, self)
+        request = RequestFactory.new(metadata, self).build_request
 
         if RAILS_VERSION < 5
           send(

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -39,7 +39,7 @@ module Rswag
         (operation_params + path_item_params + security_params)
           .map { |p| p['$ref'] ? resolve_parameter(p['$ref'], swagger_doc) : p }
           .uniq { |p| p[:name] }
-          .reject { |p| p[:required] == false && !headers.key?(p[:name]) }
+          .reject { |p| p[:required] == false && !headers.key?(p[:name]) && !params.key?(p[:name]) }
       end
 
       def derive_security_params(metadata, swagger_doc)
@@ -114,7 +114,7 @@ module Rswag
             path_template.gsub!("{#{p[:name]}}", params.fetch(p[:name]).to_s)
           end
 
-          parameters.select { |p| p[:in] == :query }.each_with_index do |p, i|
+          parameters.select { |p| p[:in] == :query && params[p[:name]] }.each_with_index do |p, i|
             path_template.concat(i.zero? ? '?' : '&')
             path_template.concat(build_query_string_part(p, params.fetch(p[:name])))
           end

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -114,7 +114,7 @@ module Rswag
             path_template.gsub!("{#{p[:name]}}", params.fetch(p[:name]).to_s)
           end
 
-          parameters.select { |p| p[:in] == :query && params[p[:name]] }.each_with_index do |p, i|
+          parameters.select { |p| p[:in] == :query && params.key?(p[:name]) }.each_with_index do |p, i|
             path_template.concat(i.zero? ? '?' : '&')
             path_template.concat(build_query_string_part(p, params.fetch(p[:name])))
           end

--- a/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
@@ -5,7 +5,8 @@ require 'rswag/specs/example_helpers'
 module Rswag
   module Specs
     RSpec.describe ExampleHelpers do
-      subject { double('example') }
+      mock_example = Struct.new(:request_headers, :request_params)
+      subject { mock_example.new({}, {}) }
 
       before do
         subject.extend(ExampleHelpers)
@@ -35,10 +36,10 @@ module Rswag
             summary: 'Updates a blog',
             consumes: ['application/json'],
             parameters: [
-              { name: :blog_id, in: :path, type: 'integer' },
+              { name: "blog_id", in: :path, type: 'integer' },
               { name: 'id', in: :path, type: 'integer' },
               { name: 'q1', in: :query, type: 'string' },
-              { name: :blog, in: :body, schema: { type: 'object' } }
+              { name: "blog", in: :body, schema: { type: 'object' } }
             ],
             security: [
               { api_key: [] }
@@ -49,11 +50,11 @@ module Rswag
 
       describe '#submit_request(metadata)' do
         before do
-          allow(subject).to receive(:blog_id).and_return(1)
-          allow(subject).to receive(:id).and_return(2)
-          allow(subject).to receive(:q1).and_return('foo')
-          allow(subject).to receive(:api_key).and_return('fookey')
-          allow(subject).to receive(:blog).and_return(text: 'Some comment')
+          subject.request_params["blog_id"] = 1
+          subject.request_params["id"] = 2
+          subject.request_params["q1"] = 'foo'
+          subject.request_params["api_key"] = 'fookey'
+          subject.request_params["blog"] = { text: 'Some comment' }
           allow(subject).to receive(:put)
           subject.submit_request(metadata)
         end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -49,7 +49,8 @@ module Rswag
           before do
             metadata[:operation][:parameters] = [
               { name: 'q1', in: :query, type: :string },
-              { name: 'q2', in: :query, type: :string }
+              { name: 'q2', in: :query, type: :string },
+              { name: 'q3', in: :query, type: :string },
             ]
             example.request_params["q1"] = 'foo'
             example.request_params["q2"] = 'bar'

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -51,13 +51,15 @@ module Rswag
               { name: 'q1', in: :query, type: :string },
               { name: 'q2', in: :query, type: :string },
               { name: 'q3', in: :query, type: :string },
+              { name: 'falsey', in: :query, type: :boolean },
             ]
             example.request_params["q1"] = 'foo'
             example.request_params["q2"] = 'bar'
+            example.request_params["falsey"] = false
           end
 
           it 'builds the query string from example values' do
-            expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
+            expect(request[:path]).to eq('/blogs?q1=foo&q2=bar&falsey=false')
           end
         end
 

--- a/test-app/spec/integration/auth_tests_spec.rb
+++ b/test-app/spec/integration/auth_tests_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' 
       security [basic_auth: []]
 
       response '204', 'Valid credentials' do
-        let(:Authorization) { "Basic #{::Base64.strict_encode64('jsmith:jspass')}" }
+        let(:request_headers) { { "Authorization" => "Basic #{::Base64.strict_encode64('jsmith:jspass')}" } }
         run_test!
       end
 
       response '401', 'Invalid credentials' do
-        let(:Authorization) { "Basic #{::Base64.strict_encode64('foo:bar')}" }
+        let(:request_headers) { { "Authorization" => "Basic #{::Base64.strict_encode64('foo:bar')}" } }
         run_test!
       end
     end
@@ -32,12 +32,12 @@ RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' 
       security [api_key: []]
 
       response '204', 'Valid credentials' do
-        let(:api_key) { 'foobar' }
+        let(:request_params) { { "api_key" => 'foobar' } }
         run_test!
       end
 
       response '401', 'Invalid credentials' do
-        let(:api_key) { 'barfoo' }
+        let(:request_params) { { "api_key" => 'barfoo' } }
         run_test!
       end
     end
@@ -50,14 +50,14 @@ RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' 
       security [{ basic_auth: [], api_key: [] }]
 
       response '204', 'Valid credentials' do
-        let(:Authorization) { "Basic #{::Base64.strict_encode64('jsmith:jspass')}" }
-        let(:api_key) { 'foobar' }
+        let(:request_headers) { { "Authorization" => "Basic #{::Base64.strict_encode64('jsmith:jspass')}" } }
+        let(:request_params) { { "api_key" => 'foobar' } }
         run_test!
       end
 
       response '401', 'Invalid credentials' do
-        let(:Authorization) { "Basic #{::Base64.strict_encode64('jsmith:jspass')}" }
-        let(:api_key) { 'barfoo' }
+        let(:request_headers) { { "Authorization" => "Basic #{::Base64.strict_encode64('jsmith:jspass')}" } }
+        let(:request_params) { { "api_key" => 'barfoo' } }
         run_test!
       end
     end

--- a/test-app/spec/integration/openapi3_spec.rb
+++ b/test-app/spec/integration/openapi3_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
             name: 'a_param',
             in: :path,
           )
-          let(:a_param) { "42" }
+          let(:request_params) { { 'a_param' => '42' } }
 
           response '200', 'OK' do
             run_test!
@@ -153,7 +153,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
             name: 'a_param',
             in: :query,
           )
-          let(:a_param) { "a foo" }
+          let(:request_params) { { 'a_param' => 'a foo' } }
 
           response '200', 'OK' do
             run_test!
@@ -186,9 +186,10 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
       post 'body is required' do
         tags 'Media Types'
         consumes 'multipart/form-data'
-        parameter name: :file, :in => :formData, :type => :file, required: true
+        parameter name: 'file', :in => :formData, :type => :file, required: true
 
-        let(:file) { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/thumbnail.png")) }
+        let(:request_params) {
+          { 'file' => Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/thumbnail.png")) } }
 
         response '200', 'OK' do
           run_test!


### PR DESCRIPTION
`#send` is dangerous to call on objects passed into your library.

Instead, this will take a page from normal RSpec request specs and allow
developers to specify a "request_params" hash and a "request_headers" hash in let blocks
that this lib can then access.

I had to use request_ because example#headers already exists in request
specs as a shorthand for integration_session.headers.

I think this also cleans up some of the logic nicely.

# RequestFactory initializer

I moved extracting the params & headers into initializer to avoid
duplicating effort.

# Warning

This will obviously break peoples' pre-existing specs, and needs to be
part of a major version change.
