### PR TITLE
Using Servers block first url during request building for OAS3 compatible documents

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -127,7 +127,7 @@ module Rswag
       def base_path_from_servers(swagger_doc)
         return '' unless swagger_doc.has_key?(:servers)
 
-        server = swagger_doc[:servers].firstt
+        server = swagger_doc[:servers].first
 
         variables = {}
         server[:variables].each_pair do |k,v|

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -102,7 +102,15 @@ module Rswag
       end
 
       def add_path(request, metadata, swagger_doc, parameters, example)
-        template = (swagger_doc[:basePath] || '') + metadata[:path_item][:template]
+        template = ''
+        if doc_version(swagger_doc).start_with?('2')
+          template = (swagger_doc[:basePath] || '')
+        else
+          template = base_path_from_servers(swagger_doc)
+        end
+
+        template +=  metadata[:path_item][:template]
+
 
         request[:path] = template.tap do |path_template|
           parameters.select { |p| p[:in] == :path }.each do |p|
@@ -113,6 +121,14 @@ module Rswag
             path_template.concat(i.zero? ? '?' : '&')
             path_template.concat(build_query_string_part(p, example.send(p[:name])))
           end
+        end
+      end
+
+      def base_path_from_servers(swagger_doc)
+        if swagger_doc[:servers].count == 1
+          URI(swagger_doc[:servers].first[:url]).path
+        else
+          URI(swagger_doc[:servers].first[:url]).path
         end
       end
 

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -125,11 +125,17 @@ module Rswag
       end
 
       def base_path_from_servers(swagger_doc)
-        if swagger_doc[:servers].count == 1
-          URI(swagger_doc[:servers].first[:url]).path
-        else
-          URI(swagger_doc[:servers].first[:url]).path
+        return '' unless swagger_doc.has_key?(:servers)
+
+        server = swagger_doc[:servers].firstt
+
+        variables = {}
+        server[:variables].each_pair do |k,v|
+          variables[k] = v[:default]
         end
+
+        url = server[:url].gsub(/\{(.*?)\}/) { variables[$1.to_sym]  }
+        URI(url).path
       end
 
       def build_query_string_part(param, value)

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -130,7 +130,7 @@ module Rswag
         server = swagger_doc[:servers].first
 
         variables = {}
-        server[:variables].each_pair do |k,v|
+        server.fetch(:variables, {}).each_pair do |k,v|
           variables[k] = v[:default]
         end
 


### PR DESCRIPTION
This PR adds support for using the servers block during test time to keep from having a v2 test configuration and v3 publish difference.