### PR TITLE
Allow use #/components/parameters and other in inherited $refs

### DIFF
--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -62,7 +62,7 @@ module Rswag
             swagger_doc.slice(:definitions)
           else
             components = swagger_doc[:components] || {}
-            { components: { schemas: components[:schemas] } }
+            { components: components }
           end
         end
       end


### PR DESCRIPTION
For the result swagger file like this
```
---
openapi: 3.0.1
info:
  title: API V1
  version: v1
paths:
  "/api/v1/posts":
    get:
      responses:
        '200':
          description: successful
          content:
            application/json:
              schema:
                "$ref": "#/components/schemas/post"
components:
  parameters:
    postServiceParam:
      name: service
      in: query
      schema:
        type: integer
  schemas:
    post:
      type: object
      properties:
        service:
          "$ref": "#/components/parameters/postServiceParam"
```

I'm getting error when run `rails rswag:specs:swaggerize`:

```
JSON::Schema::SchemaError:
       The fragment '/components/parameters' does not exist on schema 46ee2b24-6e61-5faa-a493-1758f8ec30a7
```

It happens because `Rswag::Specs::ResponseValidator#definitions_or_component_schemas` load only components/schemas. OpenApi specification does not prohibit the use components/parameters refs in components/schemas.