### PR TITLE
Show the response body for comparison when schema checks fail

### DIFF
--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -50,7 +50,11 @@ module Rswag
           .merge(schemas)
 
         errors = JSON::Validator.fully_validate(validation_schema, body)
-        raise UnexpectedResponse, "Expected response body to match schema: #{errors[0]}" if errors.any?
+        return unless errors.any?
+
+        raise UnexpectedResponse,
+              "Expected response body to match schema: #{errors[0]}\n" \
+              "Response body: #{JSON.pretty_generate(JSON.parse(body))}"
       end
 
       def definitions_or_component_schemas(swagger_doc, version)


### PR DESCRIPTION
When schema validation fails, we get information about why the body did not match the schema, but it's not very useful unless we know the _contents_ of the body itself.  This PR adds the response body to schema validation errors, similar to how it's done in the `validate_code!` method in this same file.