### PR TITLE
Only write YAML for tests that ran

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -17,7 +17,7 @@ module Rswag
       def initialize(output, config = Rswag::Specs.config)
         @output = output
         @config = config
-        @swagger_docs_affected = Set.new
+        @swagger_docs_affected = []
 
         @output.puts 'Generating Swagger docs ...'
       end
@@ -36,7 +36,7 @@ module Rswag
         return unless metadata.key?(:response)
 
         swagger_doc = @config.get_swagger_doc(metadata[:swagger_doc])
-        @swagger_docs_affected.add(swagger_doc)
+        @swagger_docs_affected << swagger_doc unless @swagger_docs_affected.include? swagger_doc
 
         unless doc_version(swagger_doc).start_with?('2')
           # This is called multiple times per file!


### PR DESCRIPTION
Our team has a separate Swagger doc that we use just for proposals of API changes.  We put those in different spec files with different `swagger_document:` values.  Those tests (for obvious reasons) won't pass yet, but we want to generate API docs for them:

* On the "real" API doc run, we want to run with `--dry-run: false` so we get fully-baked schema examples
* On the "proposal" API doc run, we just want the schema as-written without running tests

So we have to run two mutually-exclusive commands - no big deal, right?  Unfortunately as written, `rswag` writes *all* Swagger documents to disk and not just the ones affected by the tests which were run.  This PR makes it so that the only YAML written is the YAML for the specs which were run.