### PR TITLE
URL-encode query params before sending them to the controller

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -119,7 +119,7 @@ module Rswag
       def build_query_string_part(param, value)
         name = param[:name]
         type = param[:type] || param.dig(:schema, :type)
-        return "#{name}=#{value}" unless type&.to_sym == :array
+        return {name => value}.to_query unless type&.to_sym == :array
 
         case param[:collectionFormat]
         when :ssv

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -45,17 +45,32 @@ module Rswag
         end
 
         context "'query' parameters" do
-          before do
-            metadata[:operation][:parameters] = [
-              { name: 'q1', in: :query, type: :string },
-              { name: 'q2', in: :query, type: :string }
-            ]
-            allow(example).to receive(:q1).and_return('foo')
-            allow(example).to receive(:q2).and_return('bar')
+          context "with multiple query parameters" do
+            before do
+              metadata[:operation][:parameters] = [
+                { name: 'q1', in: :query, type: :string },
+                { name: 'q2', in: :query, type: :string }
+              ]
+              allow(example).to receive(:q1).and_return('foo')
+              allow(example).to receive(:q2).and_return('bar')
+            end
+
+            it 'builds the concatenated query string from example values' do
+              expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
+            end
           end
 
-          it 'builds the query string from example values' do
-            expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
+          context 'with URL-encoded query parameters' do
+            before do
+              metadata[:operation][:parameters] = [
+                { name: 'q1', in: :query, type: :string }
+              ]
+              allow(example).to receive(:q1).and_return('+url encoded')
+            end
+
+            it 'builds the concatenated query string from example values' do
+              expect(request[:path]).to eq('/blogs?q1=%2Burl+encoded')
+            end
           end
         end
 


### PR DESCRIPTION
Our `rswag` specs used a query param with a `+` symbol as the value in a test.  Once this spec had made its way into the controller, the `+` had been converted into a space character because it already assumed it was URL-encoded.

I'm not sure what the expectations are for query param examples - should we presume the user has already URL-encoded it?

This PR presumes that the user is providing a raw query param value as though someone had typed it into an address bar - this might be a breaking change for people who have come to rely on this behavior.