### PR TITLE
Document using multiple tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ There is also a generator which can help get you started `rails generate rspec:s
       path '/blogs/{id}' do
 
         get 'Retrieves a blog' do
-          tags 'Blogs'
+          tags 'Blogs', 'Another Tag'
           produces 'application/json', 'application/xml'
           parameter name: :id, in: :path, type: :string
 


### PR DESCRIPTION
Maybe this isn't necessary.  I had an especially dense moment today trying to put multiple tags on an endpoint.  I tried

```
tags %w{Cats Dogs}
```

and

```
tags Cats
tags Dogs
```

(and a few things involving byebug that I'm ashamed to mention) before I realized that these are comma-separated method arguments.  Hopefully this PR can save someone else the trouble if they're reading the docs on a day they're, well, a few cards short of a full deck ;)