### PR TITLE
Add 'getter' option to parameters to avoid name conflicts

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -55,6 +55,7 @@ module Rswag
               v.each_pair do |_verb, value|
                 is_hash = value.is_a?(Hash)
                 if is_hash && value.dig(:parameters)
+                  value.dig(:parameters).each{|p| remove_invalid_parameters_keys!(p)}
                   schema_param = value.dig(:parameters)&.find { |p| (p[:in] == :body || p[:in] == :formData) && p[:schema] }
                   mime_list = value.dig(:consumes) || doc[:consumes]
                   if value && schema_param && mime_list
@@ -198,6 +199,11 @@ module Rswag
         is_hash = value.is_a?(Hash)
         value.delete(:consumes) if is_hash && value.dig(:consumes)
         value.delete(:produces) if is_hash && value.dig(:produces)
+      end
+
+      def remove_invalid_parameters_keys!(value)
+        is_hash = value.is_a?(Hash)
+        value.delete(:getter) if is_hash && value.dig(:getter)
       end
     end
   end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -30,13 +30,13 @@ module Rswag
 
         context "'path' parameters" do
           before do
-            metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
+            metadata[:path_item][:template]   = '/blogs/{blog_id}/comments/{id}'
             metadata[:operation][:parameters] = [
               { name: 'blog_id', in: :path, type: :number },
-              { name: 'id', in: :path, type: :number }
+              { name: 'id', getter: 'id_param', in: :path, type: :number }
             ]
             allow(example).to receive(:blog_id).and_return(1)
-            allow(example).to receive(:id).and_return(2)
+            allow(example).to receive(:id_param).and_return(2)
           end
 
           it 'builds the path from example values' do
@@ -48,10 +48,10 @@ module Rswag
           before do
             metadata[:operation][:parameters] = [
               { name: 'q1', in: :query, type: :string },
-              { name: 'q2', in: :query, type: :string }
+              { name: 'q2', getter: :q2_param, in: :query, type: :string }
             ]
             allow(example).to receive(:q1).and_return('foo')
-            allow(example).to receive(:q2).and_return('bar')
+            allow(example).to receive(:q2_param).and_return('bar')
           end
 
           it 'builds the query string from example values' do
@@ -62,55 +62,61 @@ module Rswag
         context "'query' parameters of type 'array'" do
           before do
             metadata[:operation][:parameters] = [
-              { name: 'things', in: :query, type: :array, collectionFormat: collection_format }
+              { name: 'things', in: :query, type: :array, collectionFormat: collection_format },
+              { name: 'stuffs', getter: :stuffs_param, in: :query, type: :array, collectionFormat: collection_format }
             ]
             allow(example).to receive(:things).and_return(['foo', 'bar'])
+            allow(example).to receive(:stuffs_param).and_return(['oof', 'rab'])
           end
 
           context 'collectionFormat = csv' do
             let(:collection_format) { :csv }
             it 'formats as comma separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo,bar')
+              expect(request[:path]).to eq('/blogs?things=foo,bar&stuffs=oof,rab')
             end
           end
 
           context 'collectionFormat = ssv' do
             let(:collection_format) { :ssv }
             it 'formats as space separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo bar')
+              expect(request[:path]).to eq('/blogs?things=foo bar&stuffs=oof rab')
             end
           end
 
           context 'collectionFormat = tsv' do
             let(:collection_format) { :tsv }
             it 'formats as tab separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo\tbar')
+              expect(request[:path]).to eq('/blogs?things=foo\tbar&stuffs=oof\trab')
             end
           end
 
           context 'collectionFormat = pipes' do
             let(:collection_format) { :pipes }
             it 'formats as pipe separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo|bar')
+              expect(request[:path]).to eq('/blogs?things=foo|bar&stuffs=oof|rab')
             end
           end
 
           context 'collectionFormat = multi' do
             let(:collection_format) { :multi }
             it 'formats as multiple parameter instances' do
-              expect(request[:path]).to eq('/blogs?things=foo&things=bar')
+              expect(request[:path]).to eq('/blogs?things=foo&things=bar&stuffs=oof&stuffs=rab')
             end
           end
         end
 
         context "'header' parameters" do
           before do
-            metadata[:operation][:parameters] = [{ name: 'Api-Key', in: :header, type: :string }]
+            metadata[:operation][:parameters] = [
+              { name: 'Api-Key', in: :header, type: :string },
+              { name: 'Token', getter: :token_param, in: :header, type: :string }
+            ]
             allow(example).to receive(:'Api-Key').and_return('foobar')
+            allow(example).to receive(:'token_param').and_return('my_token')
           end
 
           it 'adds names and example values to headers' do
-            expect(request[:headers]).to eq({ 'Api-Key' => 'foobar' })
+            expect(request[:headers]).to eq({ 'Api-Key' => 'foobar', 'Token' => 'my_token' })
           end
         end
 
@@ -118,7 +124,7 @@ module Rswag
           before do
             metadata[:operation][:parameters] = [
               { name: 'q1', in: :query, type: :string, required: false },
-              { name: 'Api-Key', in: :header, type: :string, required: false }
+              { name: 'Api-Key', getter: :api_key, in: :header, type: :string, required: false }
             ]
           end
 
@@ -162,7 +168,7 @@ module Rswag
 
           context 'form payload' do
             before do
-              metadata[:operation][:consumes] = ['multipart/form-data']
+              metadata[:operation][:consumes]   = ['multipart/form-data']
               metadata[:operation][:parameters] = [
                 { name: 'f1', in: :formData, type: :string },
                 { name: 'f2', in: :formData, type: :string }
@@ -173,9 +179,9 @@ module Rswag
 
             it 'sets payload to hash of names and example values' do
               expect(request[:payload]).to eq(
-                'f1' => 'foo blah',
-                'f2' => 'bar blah'
-              )
+                                             'f1' => 'foo blah',
+                                             'f2' => 'bar blah'
+                                           )
             end
           end
         end
@@ -206,7 +212,7 @@ module Rswag
           context 'swagger 2.0' do
             before do
               swagger_doc[:securityDefinitions] = { basic: { type: :basic } }
-              metadata[:operation][:security] = [basic: []]
+              metadata[:operation][:security]   = [basic: []]
               allow(example).to receive(:Authorization).and_return('Basic foobar')
             end
 
@@ -218,7 +224,7 @@ module Rswag
           context 'openapi 3.0.1' do
             let(:swagger_doc) { { openapi: '3.0.1' } }
             before do
-              swagger_doc[:components] = { securitySchemes: { basic: { type: :basic } } }
+              swagger_doc[:components]        = { securitySchemes: { basic: { type: :basic } } }
               metadata[:operation][:security] = [basic: []]
               allow(example).to receive(:Authorization).and_return('Basic foobar')
             end
@@ -233,14 +239,14 @@ module Rswag
             before do
               allow(ActiveSupport::Deprecation).to receive(:warn)
               swagger_doc[:securityDefinitions] = { basic: { type: :basic } }
-              metadata[:operation][:security] = [basic: []]
+              metadata[:operation][:security]   = [basic: []]
               allow(example).to receive(:Authorization).and_return('Basic foobar')
             end
 
             it 'warns the user to upgrade' do
               expect(request[:headers]).to eq('HTTP_AUTHORIZATION' => 'Basic foobar')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                .with('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
+                                                      .with('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
               expect(swagger_doc[:components]).to have_key(:securitySchemes)
             end
           end
@@ -249,7 +255,7 @@ module Rswag
         context 'apiKey' do
           before do
             swagger_doc[:securityDefinitions] = { apiKey: { type: :apiKey, name: 'api_key', in: key_location } }
-            metadata[:operation][:security] = [apiKey: []]
+            metadata[:operation][:security]   = [apiKey: []]
             allow(example).to receive(:api_key).and_return('foobar')
           end
 
@@ -290,7 +296,7 @@ module Rswag
         context 'oauth2' do
           before do
             swagger_doc[:securityDefinitions] = { oauth2: { type: :oauth2, scopes: ['read:blogs'] } }
-            metadata[:operation][:security] = [oauth2: ['read:blogs']]
+            metadata[:operation][:security]   = [oauth2: ['read:blogs']]
             allow(example).to receive(:Authorization).and_return('Bearer foobar')
           end
 
@@ -302,10 +308,10 @@ module Rswag
         context 'paired security requirements' do
           before do
             swagger_doc[:securityDefinitions] = {
-              basic: { type: :basic },
+              basic:   { type: :basic },
               api_key: { type: :apiKey, name: 'api_key', in: :query }
             }
-            metadata[:operation][:security] = [{ basic: [], api_key: [] }]
+            metadata[:operation][:security]   = [{ basic: [], api_key: [] }]
             allow(example).to receive(:Authorization).and_return('Basic foobar')
             allow(example).to receive(:api_key).and_return('foobar')
           end
@@ -332,7 +338,7 @@ module Rswag
         context 'referenced parameters' do
           context 'swagger 2.0' do
             before do
-              swagger_doc[:parameters] = { q1: { name: 'q1', in: :query, type: :string } }
+              swagger_doc[:parameters]          = { q1: { name: 'q1', in: :query, type: :string } }
               metadata[:operation][:parameters] = [{ '$ref' => '#/parameters/q1' }]
               allow(example).to receive(:q1).and_return('foo')
             end
@@ -345,7 +351,7 @@ module Rswag
           context 'openapi 3.0.1' do
             let(:swagger_doc) { { openapi: '3.0.1' } }
             before do
-              swagger_doc[:components] = { parameters: { q1: { name: 'q1', in: :query, type: :string } } }
+              swagger_doc[:components]          = { parameters: { q1: { name: 'q1', in: :query, type: :string } } }
               metadata[:operation][:parameters] = [{ '$ref' => '#/components/parameters/q1' }]
               allow(example).to receive(:q1).and_return('foo')
             end
@@ -359,7 +365,7 @@ module Rswag
             let(:swagger_doc) { { openapi: '3.0.1' } }
             before do
               allow(ActiveSupport::Deprecation).to receive(:warn)
-              swagger_doc[:parameters] = { q1: { name: 'q1', in: :query, type: :string } }
+              swagger_doc[:parameters]          = { q1: { name: 'q1', in: :query, type: :string } }
               metadata[:operation][:parameters] = [{ '$ref' => '#/parameters/q1' }]
               allow(example).to receive(:q1).and_return('foo')
             end
@@ -367,9 +373,9 @@ module Rswag
             it 'warns the user to upgrade' do
               expect(request[:path]).to eq('/blogs?q1=foo')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                .with('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
+                                                      .with('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
               expect(ActiveSupport::Deprecation).to have_received(:warn)
-                .with('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
+                                                      .with('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
             end
           end
         end
@@ -393,7 +399,7 @@ module Rswag
         context 'global security requirements' do
           before do
             swagger_doc[:securityDefinitions] = { apiKey: { type: :apiKey, name: 'api_key', in: :query } }
-            swagger_doc[:security] = [apiKey: []]
+            swagger_doc[:security]            = [apiKey: []]
             allow(example).to receive(:api_key).and_return('foobar')
           end
 


### PR DESCRIPTION
Add an option `getter` to `parameters`. This option allows users to override the name of method to use to retrieve the parameter value (generally, the name of the associated `let`).

I made this to avoid name conflict with rspec default matcher `include`.
This is a known issue : https://github.com/rswag/rswag/issues/188

I also cleaned up this option in the Formatter but there is currently no test for the `stop(notification)` callback