### PR TITLE
Better error message for missing let

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -194,11 +194,35 @@ module Rswag
 
       def build_json_payload(parameters, example)
         body_param = parameters.select { |p| p[:in] == :body }.first
-        body_param ? example.send(body_param[:name]).to_json : nil
+
+        return nil unless body_param
+
+        raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
+
+        example.send(body_param[:name]).to_json
       end
 
       def doc_version(doc)
         doc[:openapi] || doc[:swagger] || '3'
+      end
+    end
+
+    class MissingParameterError < StandardError
+      attr_reader :body_param
+
+      def initialize(body_param)
+        @body_param = body_param
+      end
+
+      def message
+        <<~MSG
+          Missing parameter #{body_param}
+
+          Please check your spec. It looks like you defined a body parameter,
+          but did not declare usage via let. Try adding:
+
+              let(:#{body_param}) {}
+        MSG
       end
     end
   end

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -216,7 +216,7 @@ module Rswag
 
       def message
         <<~MSG
-          Missing parameter #{body_param}
+          Missing parameter '#{body_param}'
 
           Please check your spec. It looks like you defined a body parameter,
           but did not declare usage via let. Try adding:

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -171,7 +171,7 @@ module Rswag
             it 'uses the referenced metadata to build the request' do
               expect do
                 request[:payload]
-              end.to raise_error(Rswag::Specs::MissingParameterError, /Missing parameter comment/)
+              end.to raise_error(Rswag::Specs::MissingParameterError, /Missing parameter 'comment'/)
             end
           end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -160,6 +160,21 @@ module Rswag
             end
           end
 
+          context 'missing body parameter' do
+            before do
+              metadata[:operation][:parameters] = [{ name: 'comment', in: :body, schema: { type: 'object' } }]
+              allow(example).to receive(:comment).and_raise(NoMethodError, "undefined method 'comment'")
+              allow(example).to receive(:respond_to?).with(:'Content-Type')
+              allow(example).to receive(:respond_to?).with('comment').and_return(false)
+            end
+
+            it 'uses the referenced metadata to build the request' do
+              expect do
+                request[:payload]
+              end.to raise_error(Rswag::Specs::MissingParameterError, /Missing parameter comment/)
+            end
+          end
+
           context 'form payload' do
             before do
               metadata[:operation][:consumes] = ['multipart/form-data']


### PR DESCRIPTION
I've run into this a number of times, and helped developers triage this
as well. This is meant to improve the developer experience by providing
an improved error message when we forget to configure a let

The original error message is actually a `NoMethodError`/`undefined method`
and it's not always immediately clear what the solution is, particularly if 
you're new to rspec/rswag

Here's an example error (the real one that prompted me to create this PR)

![image](https://user-images.githubusercontent.com/191564/128745129-4fe14ffb-d7e6-44dd-9435-1a07dc435ca8.png)

And the new error message:

![image](https://user-images.githubusercontent.com/191564/128745596-3f827f3b-6a36-4b5d-990f-b5ba9ff6f6d1.png)

I have a number of other small changes like this that I can contribute as well
if these types of pull requests are welcome.