### PR TITLE
Loosen gemspec requirement to allow rails 7.0

### DIFF
--- a/rswag-api/rswag-api.gemspec
+++ b/rswag-api/rswag-api.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']
 
-  s.add_dependency 'railties', '>= 3.1', '< 7.0'
+  s.add_dependency 'railties', '>= 3.1', '< 7.1'
 end

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']
 
-  s.add_dependency 'activesupport', '>= 3.1', '< 7.0'
-  s.add_dependency 'railties', '>= 3.1', '< 7.0'
+  s.add_dependency 'activesupport', '>= 3.1', '< 7.1'
+  s.add_dependency 'railties', '>= 3.1', '< 7.1'
   s.add_dependency 'json-schema', '~> 2.2'
 end

--- a/rswag-ui/rswag-ui.gemspec
+++ b/rswag-ui/rswag-ui.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,node_modules}/**/*') + ['MIT-LICENSE', 'Rakefile' ]
 
-  s.add_dependency 'actionpack', '>=3.1', '< 7.0'
-  s.add_dependency 'railties', '>= 3.1', '< 7.0'
+  s.add_dependency 'actionpack', '>=3.1', '< 7.1'
+  s.add_dependency 'railties', '>= 3.1', '< 7.1'
 end


### PR DESCRIPTION
Tests are passing locally using `./ci/test.sh` with `ruby 2.7.1p83`
```
Finished in 0.44644 seconds (files took 3.78 seconds to load)
26 examples, 0 failures, 2 pending

Finished in 5.5 seconds (files took 4.57 seconds to load)
28 examples, 0 failures, 3 pending
```
Any objection to this loosening? We have a codebase and we want to do some testing of the alpha release of Rails 7.