### PR TITLE
Fix request building with formData parameters

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -253,10 +253,8 @@ module Rswag
         # Rather that serializing with the appropriate encoding (e.g. multipart/form-data),
         # Rails test infrastructure allows us to send the values directly as a hash
         # PROS: simple to implement, CONS: serialization/deserialization is bypassed in test
-        tuples = parameters
-          .select { |p| p[:in] == :formData }
-          .map { |p| [p[:name], example.send(p[:name])] }
-        Hash[tuples]
+        form_data_param = parameters.select { |p| p[:in] == :formData }.first
+        form_data_param ? example.send(form_data_param[:name]) : {}
       end
 
       def build_json_payload(parameters, example)

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -344,19 +344,12 @@ module Rswag
           context 'form payload' do
             before do
               metadata[:operation][:consumes] = ['multipart/form-data']
-              metadata[:operation][:parameters] = [
-                { name: 'f1', in: :formData, type: :string },
-                { name: 'f2', in: :formData, type: :string }
-              ]
-              allow(example).to receive(:f1).and_return('foo blah')
-              allow(example).to receive(:f2).and_return('bar blah')
+              metadata[:operation][:parameters] = [{ name: 'comment', in: :formData, schema: { type: 'object' } }]
+              allow(example).to receive(:comment).and_return(text: 'Some comment')
             end
 
-            it 'sets payload to hash of names and example values' do
-              expect(request[:payload]).to eq(
-                'f1' => 'foo blah',
-                'f2' => 'bar blah'
-              )
+            it "sets payload to hash of names from first 'formData' parameter" do
+              expect(request[:payload]).to eq(text: 'Some comment')
             end
           end
         end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -141,15 +141,19 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       operationId 'uploadThumbnailBlog'
       consumes 'multipart/form-data'
       parameter(
-        name: :file,
+        name: :form_data,
         description: "The content of the blog thumbnail",
         in: :formData,
-        type: :file,
+        type: :object,
+        properties: {
+          file: { type: :file },
+        },
         required: true
       )
 
       response '200', 'blog updated' do
-        let(:file) { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/thumbnail.png")) }
+        let(:form_data) { { file: file } }
+        let(:file) { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/thumbnail.png')) }
         run_test!
       end
     end

--- a/test-app/spec/integration/openapi3_spec.rb
+++ b/test-app/spec/integration/openapi3_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
     swagger_root = File.expand_path('tmp/swagger', __dir__)
     config = double('config', swagger_root: swagger_root, get_swagger_doc: swagger_doc )
     formatter = Rswag::Specs::SwaggerFormatter.new(output, config)
-    
+
     example_group = OpenStruct.new(group: OpenStruct.new(metadata: example.metadata))
     formatter.example_group_finished(example_group)
   end
@@ -68,7 +68,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
               url: "https://{defaultHost}/foo",
               variables: {
                 defaultHost: {
-                  default: "api.example.com" 
+                  default: "api.example.com"
                 }
               }
             }]}
@@ -79,7 +79,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
                 url: "https://{defaultHost}/foo",
                 variables: {
                   defaultHost: {
-                    default: "api.example.com" 
+                    default: "api.example.com"
                   }
                 }
               }])
@@ -186,16 +186,22 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
       post 'body is required' do
         tags 'Media Types'
         consumes 'multipart/form-data'
-        parameter name: :file, :in => :formData, :type => :file, required: true
+        parameter name: :form_data, in: :formData, schema: {
+          type: :object,
+          properties: {
+            file: { type: :file }
+          }
+        }
 
-        let(:file) { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/thumbnail.png")) }
+        let(:form_data) { { file: file } }
+        let(:file) { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/thumbnail.png')) }
 
         response '200', 'OK' do
           run_test!
 
           it 'declares requestBody is required' do
             pending "This output is massaged in SwaggerFormatter#stop, and isn't quite ready here to assert"
-            tree = swagger_doc.dig(:paths, "/stubs", :post, :requestBody)
+            tree = swagger_doc.dig(:paths, '/stubs', :post, :requestBody)
             expect(tree[:required]).to eq(true)
           end
         end

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -277,7 +277,12 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "file"
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "file"
+                  }
+                }
               }
             }
           },

--- a/test-app/swagger/v3/openapi.json
+++ b/test-app/swagger/v3/openapi.json
@@ -40,11 +40,15 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "file"
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "file"
+                  }
+                }
               }
             }
-          },
-          "required": true
+          }
         }
       }
     },


### PR DESCRIPTION
## Problem
Swaggerization part and request building part of `formData` parameters behave differently. With [this commit](https://github.com/rswag/rswag/commit/2af7c13e59a1bacccdd8136db93894acf0e71dac) `formData` parameters are being filtered out and only the first one's `:schema` definition is used inside endpoint description (same as with `body` parameters). However, in `request_factory` every single `formData` param is used to build a payload.
So with parameter definition like this:
```ruby
parameter name: :name, in: :formData, type: :string

let(:name) { 'Name' }
```
An empty `requestBody` definition for that API action is generated  (because there is no `:schema` key)

With this variation:
```ruby
parameter name: :form_data, in: :formData, schema: { type: :object, properties: { name: { type: :string } } }

let(:form_data) { { name: :name } }
let(:name) { 'Name'}
```
the correct swagger definition is generated, but the controller receives the `name` parameter that is nested inside the `form_data` object. And this does not match the defined schema.

## Solution
This can be fixed by either changing `request_factory` so it puts first `formData` parameter inside request body (implemented in this PR), or changing `swagger_formatter` so that it builds schema definition from multiple `formData` parameters. Don't know the reason why `swagger_formatter` was initially implemented this way, so I went with the first option.