### PR TITLE
add custom error in case user forgets to define name with let

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -106,6 +106,10 @@ module Rswag
 
         request[:path] = template.tap do |path_template|
           parameters.select { |p| p[:in] == :path }.each do |p|
+            unless example.respond_to?(p[:name])
+              raise ArgumentError.new("`#{p[:name].to_s}` parameter key present, but not defined within example group"\
+                "(i. e `it` or `let` block)")
+            end
             path_template.gsub!("{#{p[:name]}}", example.send(p[:name]).to_s)
           end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -29,18 +29,36 @@ module Rswag
         end
 
         context "'path' parameters" do
-          before do
-            metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
-            metadata[:operation][:parameters] = [
-              { name: 'blog_id', in: :path, type: :number },
-              { name: 'id', in: :path, type: :number }
-            ]
-            allow(example).to receive(:blog_id).and_return(1)
-            allow(example).to receive(:id).and_return(2)
+          context 'when `name` parameter key is required, but not defined within example group' do
+            before do
+              metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
+              metadata[:operation][:parameters] = [
+                { name: 'blog_id', in: :path, type: :number },
+                { name: 'id', in: :path, type: :number }
+              ]
+            end
+
+            it "explicitly warns user about missing parameter, instead of giving generic error" do
+              expect { request[:path] }.not_to raise_error(/undefined method/)
+              expect { request[:path] }.not_to raise_error(/is not available from within an example/)
+              expect { request[:path] }.to raise_error(/parameter key present, but not defined/)
+            end
           end
 
-          it 'builds the path from example values' do
-            expect(request[:path]).to eq('/blogs/1/comments/2')
+          context 'when `name` is defined' do
+            before do
+              metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
+              metadata[:operation][:parameters] = [
+                { name: 'blog_id', in: :path, type: :number },
+                { name: 'id', in: :path, type: :number }
+              ]
+              allow(example).to receive(:blog_id).and_return(1)
+              allow(example).to receive(:id).and_return(2)
+            end
+
+            it 'builds the path from example values' do
+              expect(request[:path]).to eq('/blogs/1/comments/2')
+            end
           end
         end
 


### PR DESCRIPTION
If you declare a name parameter, but forget to define it within `it` or `let` group, RSpec will raise undescriptive error. Two things can happen:
1. Usually it will raise `NoMethodError`. Which is mostly true, but it's very generic and doesn't say anything about the place where this error happened and how to fix it.
```ruby
undefined method `blog_id' for #<RSpec::ExampleGroups::ApiTrackers::ApiTrackersIdd::Get::Successful:0x000055e89bf1dab8>
```
2. Some variables like `id` can raise `WrongScopeError`
```ruby
`id` is not available from within an example (e.g. an `it` block) or from constructs that run in the scope of an example (e.g. `before`, `let`, etc). It is only available on an example group (e.g. a `describe` or `context` block).
```
The text of this error is just wrong and sends user on wild goose chase. 

 This pull request adds custom error to remind user to define the missing variable.