### PR TITLE
Display all validation errors not just first

### DIFF
--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -53,7 +53,7 @@ module Rswag
         return unless errors.any?
 
         raise UnexpectedResponse,
-              "Expected response body to match schema: #{errors[0]}\n" \
+              "Expected response body to match schema: #{errors.join("\n")}\n" \
               "Response body: #{JSON.pretty_generate(JSON.parse(body))}"
       end
 

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -21,8 +21,11 @@ module Rswag
             headers: { 'X-Rate-Limit-Limit' => { type: :integer } },
             schema: {
               type: :object,
-              properties: { text: { type: :string } },
-              required: ['text']
+              properties: {
+                text: { type: :string },
+                number: { type: :integer }
+              },
+              required: ['text', 'number']
             }
           }
         }
@@ -34,7 +37,7 @@ module Rswag
           OpenStruct.new(
             code: '200',
             headers: { 'X-Rate-Limit-Limit' => '10' },
-            body: '{"text":"Some comment"}'
+            body: '{"text":"Some comment", "number": 3}'
           )
         end
 


### PR DESCRIPTION
Currently we only see the first error from a validation error, rather than all of them - this change means that the user will see each error on a new line