### PR TITLE
Fix github actions to use a matching Ruby version 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
-      with: { ruby-version: 2.6 }
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - uses: actions/cache@v2
       id: cache


### PR DESCRIPTION
Currently, the github actions always use Ruby 2.6 even though there are a couple of other versions specified. For example https://github.com/rswag/rswag/runs/4413833399?check_suite_focus=true.

![image](https://user-images.githubusercontent.com/9660258/148847914-c0df0d45-9874-4ba1-b5f4-d3ff549aac73.png)

This fix here will use a matching Ruby version based on the matrix, Following the setup-ruby action doc https://github.com/ruby/setup-ruby#matrix-of-ruby-versions