### PR TITLE
Use File.exist? instead of File.exists?

### DIFF
--- a/rswag-ui/lib/rswag/ui/middleware.rb
+++ b/rswag-ui/lib/rswag/ui/middleware.rb
@@ -37,7 +37,7 @@ module Rswag
       end
 
       def template_filename
-        @config.template_locations.find { |filename| File.exists?(filename) }
+        @config.template_locations.find { |filename| File.exist?(filename) }
       end
     end
   end


### PR DESCRIPTION
It seems Ruby 3.1 will remove File.exists? which has been obsolete for quite some time.
This fixes the deprecation warning: `rswag-ui-2.4.0/lib/rswag/ui/middleware.rb:40: warning: File.exists? is deprecated; use File.exist? instead`
File.exist? already exists since ruby 1.8.7: https://ruby-doc.org/core-1.8.7/File.html#method-c-exist-3F