### PR TITLE
keep existing metadata in requestBody.content.mime

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -61,7 +61,7 @@ module Rswag
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     value[:requestBody][:required] = true if schema_param[:required]
                     mime_list.each do |mime|
-                      value[:requestBody][:content][mime] = { schema: schema_param[:schema] }
+                      (value[:requestBody][:content][mime] ||= {})[:schema] = schema_param[:schema]
                     end
                   end
 


### PR DESCRIPTION
This allows for adding multiple `requestBody` `examples` via metadata.

```ruby
after do |example|
  media_type = request.media_type
  example.metadata[:operation].deep_merge!(requestBody: { content: { media_type => { examples: {} } } })
  example.metadata[:operation][:requestBody][:content][media_type][:examples].tap { |e|
    e[e.size] = {
      summary: example.example_group.description,
      description: example.description,
      value: request.body.string
    }
  }
end
```

I tries to add specs, but didn't quite understand the existing specs. Hope the sample above helps to understand my intent