### PR TITLE
Remove requirement to include invalid 'consumes' attribute

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -56,8 +56,7 @@ module Rswag
                 is_hash = value.is_a?(Hash)
                 if is_hash && value.dig(:parameters)
                   schema_param = value.dig(:parameters)&.find { |p| (p[:in] == :body || p[:in] == :formData) && p[:schema] }
-                  mime_list = value.dig(:consumes) || doc[:consumes]
-                  if value && schema_param && mime_list
+                  if value && schema_param
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     value[:requestBody][:required] = true if schema_param[:required]
                     mime_list.each do |mime|


### PR DESCRIPTION
I have made this PR in an attempt to fix a problem with rswag's compatibility with OpenAPI v3.

Currently, the only way I can get rswag to produce `requestBody` on a request is to include the attribute 'consumes' on the root of the document. 

This attribute, however, is invalid in OpenAPI v3. I suggest we remove the requirement to include the invalid attribute 'consumes'. 