### PR TITLE
Fix truffleruby workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, truffleruby-head]
+        ruby: [2.6, 2.7, truffleruby]
         rails: [5.2.4.4, 6.0.3.4]
     env:
       RAILS_VERSION: ${{ matrix.rails }}


### PR DESCRIPTION
using truffleruby-head is supported
https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
However for us it times out. Unclear why.
https://github.com/rswag/rswag/runs/4912391605?check_suite_focus=true
This continues #470 