### PR TITLE
Testing env improvements - add test environments and bump versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,6 +20,9 @@ jobs:
           ruby: 3.0
         - rails: 5.2.6
           ruby: 3.1
+        # Rails 7.0.1 requires >= 2.7.0, so excluding 2.6
+        - rails: 7.0.1
+          ruby: 2.6
     env:
       RAILS_VERSION: ${{ matrix.rails }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, truffleruby-head]
+        ruby: [2.6, 2.7, 3.0, 3.1, truffleruby-head] # 2.6 is EOL March 31, 2022
         rails: [5.2.6, 6.1.4.4, 7.0.1] # Tested against latest of every Rails version since 5.x
     env:
       RAILS_VERSION: ${{ matrix.rails }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.6, 2.7, truffleruby-head]
-        rails: [5.2.4.4, 6.0.3.4]
+        rails: [5.2.6, 6.1.4.4, 7.0.1] # Tested against latest of every Rails version since 5.x
     env:
       RAILS_VERSION: ${{ matrix.rails }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1, truffleruby-head] # 2.6 is EOL March 31, 2022.
+        ruby: [2.6, 2.7, 3.0, 3.1] # 2.6 is EOL March 31, 2022.
         rails: [5.2.6, 6.1.4.4, 7.0.1] # 5.2 EOL in 01 Jun 2022
         exclude:
         # excludes Rails 5.2.x on Ruby 3.0 and on 3.1 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,8 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0, 3.1, truffleruby-head] # 2.6 is EOL March 31, 2022
-        rails: [5.2.6, 6.1.4.4, 7.0.1] # Tested against latest of every Rails version since 5.x
+        ruby: [2.6, 2.7, 3.0, 3.1, truffleruby-head] # 2.6 is EOL March 31, 2022.
+        rails: [5.2.6, 6.1.4.4, 7.0.1] # 5.2 EOL in 01 Jun 2022
+        exclude:
+        # excludes Rails 5.2.x on Ruby 3.0 and on 3.1 
+        # Note that 6.0.x should also exclude 3.0 and 3.1 but we're not testing it.
+        - rails: 5.2.6
+          ruby: 3.0
+        - rails: 5.2.6
+          ruby: 3.1
     env:
       RAILS_VERSION: ${{ matrix.rails }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.7
+ENV RAILS_VERSION 7.0.1
+
+RUN apt-get update -qq && apt-get install -y nodejs npm
+WORKDIR /rswag
+COPY . /rswag
+
+RUN "./ci/build.sh"
+
+# Configure the main process to run when running the image
+EXPOSE 3000
+WORKDIR /rswag/test-app
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,11 @@ when  '6', '7'
   gem 'sqlite3', '~> 1.4.1'
 end
 
+case RUBY_VERSION.split('.').first
+when '3'
+  gem 'net-smtp', require: false
+end
+
 gem 'rswag-api', path: './rswag-api'
 gem 'rswag-ui', path: './rswag-ui'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,21 +4,16 @@ source 'https://rubygems.org'
 
 # Allow the rails version to come from an ENV setting so Travis can test multiple versions.
 # See http://www.schneems.com/post/50991826838/testing-against-multiple-rails-versions/
-rails_version = ENV['RAILS_VERSION'] || '5.2.4.2'
+rails_version = ENV['RAILS_VERSION'] || '5.2.6'
 
 gem 'rails', rails_version.to_s
 
-case rails_version.split('.').first
-when '3'
-  gem 'strong_parameters'
-when '4', '5', '6'
-  gem 'responders'
-end
+gem 'responders'
 
 case rails_version.split('.').first
-when '3', '4', '5'
+when '5'
   gem 'sqlite3', '~> 1.3.6'
-when  '6'
+when  '6', '7'
   gem 'sqlite3', '~> 1.4.1'
 end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  test-app: &base-test
+    container_name: rswag
+    image: rswag
+    ports:
+      - 3000:3000
+    build:
+      context: .
+    volumes:
+       - ./test-app:/rswag/test-app
+  test:
+    <<: *base-test
+    command: sh -c 'bundle exec rake db:setup && bundle exec rspec'

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require "active_support"
 require 'active_support/core_ext/hash/slice'
 require 'active_support/core_ext/hash/conversions'
 require 'json'

--- a/test-app/config/application.rb
+++ b/test-app/config/application.rb
@@ -4,7 +4,7 @@ require File.expand_path('../boot', __FILE__)
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "sprockets/railtie"
+# require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)
@@ -55,10 +55,10 @@ module TestApp
     # config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
-    config.assets.enabled = true
+    # config.assets.enabled = true
 
     # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
+    # config.assets.version = '1.0'
   end
 end
 

--- a/test-app/config/environments/development.rb
+++ b/test-app/config/environments/development.rb
@@ -24,10 +24,10 @@ TestApp::Application.configure do
 
 
   # Do not compress assets
-  config.assets.compress = false
+  # config.assets.compress = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  # config.assets.debug = true
 
   config.eager_load = false
 end


### PR DESCRIPTION
Some housekeeping:

* Bumps patch and minor versions on test matrix
* Adds Rails 7 to test matrix
* Adds Ruby 3.0 and 3.1 ( Excluding older Rails versions from tests in Ruby 3.x )
  * Docs [for excluding envs here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-configurations-from-a-matrix)
* Adds some annotations about EOLs of testing environments
* Adds a Docker and Docker compose to easily debug in any environment (ARM64 makes it sometimes tricky to use older Ruby versions)
* Removes `truffleruby-head` from the test matrix as it was a bit discussed on the PRs Greg authored. -- eg https://github.com/rswag/rswag/pull/479#issuecomment-1019474574