### PR TITLE
Examples to OAS3 - partially breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,11 +594,16 @@ describe 'Blogs API' do
     get 'Retrieves a blog' do
 
       response 200, 'blog found' do
-        examples 'application/json' => {
+        example 'application/json', :example_key, {
             id: 1,
             title: 'Hello world!',
             content: '...'
           }
+        example 'application/json', :example_key_2, {
+            id: 1,
+            title: 'Hello world!',
+            content: '...'
+          }, "Summary of the example", "Longer description of the example"
   ...
 end
 ```
@@ -611,9 +616,12 @@ To enable examples generation from responses add callback above run_test! like:
 
 ```
 after do |example|
-  example.metadata[:response][:content] = {
-    'application/json' => {
-      example: JSON.parse(response.body, symbolize_names: true)
+  example.metadata[:response][:examples]['application/json'] = {
+      example_1: {
+        value: JSON.parse(response.body, symbolize_names: true)
+        summary: "Summary (optional)"
+        description: "Description (Optional)"
+      }
     }
   }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
        - .:/rswag
   test:
     <<: *base-test
-    command: sh -c 'cd .. && ./ci/build.sh && cd test-app && bundle exec rake db:setup && bundle exec rspec'
+    command: sh -c 'cd .. && ./ci/test.sh'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
     volumes:
-       - ./test-app:/rswag/test-app
+       - .:/rswag
   test:
     <<: *base-test
-    command: sh -c 'bundle exec rake db:setup && bundle exec rspec'
+    command: sh -c 'cd .. && ./ci/build.sh && cd test-app && bundle exec rake db:setup && bundle exec rspec'

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -52,7 +52,7 @@ module Rswag
       end
 
       def response(code, description, metadata = {}, &block)
-        metadata[:response] = { code: code, description: description }
+        metadata[:response] = { code: code, description: description, examples: {}}
         context(description, metadata, &block)
       end
 
@@ -69,13 +69,28 @@ module Rswag
       # NOTE: Similar to 'description', 'examples' need to handle the case when
       # being invoked with no params to avoid overriding 'examples' method of
       # rspec-core ExampleGroup
-      def examples(example = nil)
-        return super() if example.nil?
+      def examples(examples = nil)
+        return super() if examples.nil?
+        # should we add a deprecation warning?
+        examples.each_with_index do |(mime, example_object), index|
+          example(mime, "example_#{index}", example_object)
+        end
+      end
 
-        metadata[:response][:content] =
-          example.each_with_object({}) do |(mime, example_object), memo|
-            memo[mime] = { example: example_object }
-          end
+      def example(mime, name, value, summary=nil, description=nil)
+
+
+
+        mime_example_group = metadata[:response][:examples][mime] || {}
+        example_object = {
+          value: value,
+          summary: summary,
+          description: description
+        }.select { |_, v| v.present? }
+        # TODO, issue a warning if example is being overrindn with the same key
+        metadata[:response][:examples][mime] = mime_example_group.merge!(
+          { name => example_object }
+        )
       end
 
       def run_test!(&block)

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -52,7 +52,7 @@ module Rswag
       end
 
       def response(code, description, metadata = {}, &block)
-        metadata[:response] = { code: code, description: description, examples: {}}
+        metadata[:response] = { code: code, description: description }
         context(description, metadata, &block)
       end
 
@@ -78,6 +78,9 @@ module Rswag
       end
 
       def example(mime, name, value, summary=nil, description=nil)
+        if metadata[:response][:examples].blank?
+          metadata[:response][:examples] = {}
+        end
         mime_example_group = metadata[:response][:examples][mime] || {}
         example_object = {
           value: value,

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -78,9 +78,6 @@ module Rswag
       end
 
       def example(mime, name, value, summary=nil, description=nil)
-
-
-
         mime_example_group = metadata[:response][:examples][mime] || {}
         example_object = {
           value: value,

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -43,6 +43,7 @@ module Rswag
           upgrade_servers!(swagger_doc)
           upgrade_oauth!(swagger_doc)
           upgrade_response_produces!(swagger_doc, metadata)
+
         end
 
         swagger_doc.deep_merge!(metadata_to_swagger(metadata))
@@ -127,16 +128,23 @@ module Rswag
         target_node = metadata[:response]
         upgrade_content!(mime_list, target_node)
         metadata[:response].delete(:schema)
+        metadata[:response].delete(:examples)
       end
 
       def upgrade_content!(mime_list, target_node)
         schema = target_node[:schema]
+        examples =  target_node[:examples]
         return if mime_list.empty? || schema.nil?
 
         target_node[:content] ||= {}
         mime_list.each do |mime_type|
           # TODO upgrade to have content-type specific schema
-          (target_node[:content][mime_type] ||= {}).merge!(schema: schema)
+          (target_node[:content][mime_type] ||= {}).merge!(
+            {
+              schema: schema,
+              examples: examples[mime_type]
+            }.select { |_, v| v.present? }
+          )
         end
       end
 

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -133,8 +133,8 @@ module Rswag
 
       def upgrade_content!(mime_list, target_node)
         schema = target_node[:schema]
-        examples =  target_node[:examples]
         return if mime_list.empty? || schema.nil?
+        examples =  target_node[:examples] || {}
 
         target_node[:content] ||= {}
         mime_list.each do |mime_type|

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -138,23 +138,24 @@ module Rswag
 
       describe '#examples(example)' do
         let(:mime) { 'application/json' }
+        let(:example_name) { :example }
         let(:json_example) do
           {
-            mime => {
               foo: 'bar'
-            }
           }
         end
         let(:api_metadata) { { response: {} } }
 
         before do
-          subject.examples(json_example)
+          subject.example(mime, example_name, json_example)
         end
 
         it "adds to the 'response examples' metadata" do
-          expect(api_metadata[:response][:content]).to match(
+          expect(api_metadata[:response][:examples]).to match(
             mime => {
-              example: json_example[mime]
+              example_name => {
+                value: json_example
+              }
             }
           )
         end

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -136,7 +136,7 @@ module Rswag
                 code: '201',
                 description: 'blog created',
                 headers: { type: :string },
-                content: { 'application/json' => { example: { foo: :bar } } },
+                examples: { 'application/json' => { foo: { value: :bar } } },
                 schema: { '$ref' => '#/definitions/blog' }
               }
             end

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -157,7 +157,11 @@ module Rswag
                             },
                             'application/json' => {
                               schema: { '$ref' => '#/definitions/blog' },
-                              example: { foo: :bar }
+                              examples: { 
+                                foo: {
+                                  value: :bar
+                                }
+                              }
                             }
                           },
                           description: 'blog created',

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define(version: 2016_02_18_212104) do
     t.string "title"
     t.text "content"
     t.string "thumbnail"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
 end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -96,10 +96,25 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
 
         schema '$ref' => '#/definitions/blog'
 
+        #Legacy
         examples 'application/json' => {
+          id: 1,
+          title: 'Hello legay world!',
+          content: 'Hello legacy world and hello universe. Thank you all very much!!!',
+          thumbnail: 'legacy-thumbnail.png'
+        }
+
+        example 'application/json', :blog_example_1, {
           id: 1,
           title: 'Hello world!',
           content: 'Hello world and hello universe. Thank you all very much!!!',
+          thumbnail: 'thumbnail.png'
+        }, "Summary of the example", "A longer description of a fine blog post about a wonderfull universe!"
+
+        example 'application/json', :blog_example_2, {
+          id: 1,
+          title: 'Another fine example!',
+          content: 'Oh... what a fine example this is, indeed, a fine example!',
           thumbnail: 'thumbnail.png'
         }
 

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -221,14 +221,36 @@
             },
             "content": {
               "application/json": {
-                "example": {
-                  "id": 1,
-                  "title": "Hello world!",
-                  "content": "Hello world and hello universe. Thank you all very much!!!",
-                  "thumbnail": "thumbnail.png"
-                },
                 "schema": {
                   "$ref": "#/definitions/blog"
+                },
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 1,
+                      "title": "Hello legay world!",
+                      "content": "Hello legacy world and hello universe. Thank you all very much!!!",
+                      "thumbnail": "legacy-thumbnail.png"
+                    }
+                  },
+                  "blog_example_1": {
+                    "value": {
+                      "id": 1,
+                      "title": "Hello world!",
+                      "content": "Hello world and hello universe. Thank you all very much!!!",
+                      "thumbnail": "thumbnail.png"
+                    },
+                    "summary": "Summary of the example",
+                    "description": "A longer description of a fine blog post about a wonderfull universe!"
+                  },
+                  "blog_example_2": {
+                    "value": {
+                      "id": 1,
+                      "title": "Another fine example!",
+                      "content": "Oh... what a fine example this is, indeed, a fine example!",
+                      "thumbnail": "thumbnail.png"
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
# DISCUSSION - What should we do with `metadata` object
I feel that the metadata internal object, which I assume was modelled after OAS2, has grew too far from the actual OAS model. The logical idea would be that the examples would be stored in `metadata[:response][:content][mime][:examples]`, but at this point I'm quite afraid of doing so, because of all te reformatting happening in `swagger_formatter.rb` 

That is why I ended up taking the direction of storing the examples data in `metadata[:response][:examples]`, where we can store them in each mime, and later transform it into:
```
metadata[:response][:content][mime_type] =
            {
              schema: schema,
              examples: examples[mime_type]
            }
```
The alternative would be to refactor and remove those `upgrade_content` that are clearly a patch between OAS2 and OAS3.
Would this be an acceptable solution, or should we start aiming towards brining the metadata object as close as possible to OAS3?

## Problem
Examples were no longer working due to OAS3. Examples moved into the mime type, and requires a new structure
https://swagger.io/specification/#example-object 

This is a partially breaking change because the docs mentioned:
```
after do |example|
  example.metadata[:response][:content] = {
    'application/json' => {
      example: JSON.parse(response.body, symbolize_names: true)
```
to generate dynamic examples. This was not working anyway, and there was no attempt at making it work at this point.

## Solution
- Created a new area to store examples per mime type. `metadata[:response][:examples][mime]` 
- Formatted the output document according to new OAS3

### This concerns this parts of the Open API Specification:
* https://swagger.io/specification/#example-object

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [x] Added documentation to README.md

