### PR TITLE
Fix examples, and upgrade examples to OAS3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixes examples for OAS3 specification, allowing multiple examples
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -594,11 +594,16 @@ describe 'Blogs API' do
     get 'Retrieves a blog' do
 
       response 200, 'blog found' do
-        examples 'application/json' => {
+        example 'application/json', :example_key, {
             id: 1,
             title: 'Hello world!',
             content: '...'
           }
+        example 'application/json', :example_key_2, {
+            id: 1,
+            title: 'Hello world!',
+            content: '...'
+          }, "Summary of the example", "Longer description of the example"
   ...
 end
 ```
@@ -611,9 +616,12 @@ To enable examples generation from responses add callback above run_test! like:
 
 ```
 after do |example|
-  example.metadata[:response][:content] = {
-    'application/json' => {
-      example: JSON.parse(response.body, symbolize_names: true)
+  example.metadata[:response][:content]['application/json'][:examples] = {
+      example_1: {
+        value: JSON.parse(response.body, symbolize_names: true)
+        summary: "Summary (optional)"
+        description: "Description (Optional)"
+      }
     }
   }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: .
     volumes:
-       - ./test-app:/rswag/test-app
+       - .:/rswag
   test:
     <<: *base-test
-    command: sh -c 'bundle exec rake db:setup && bundle exec rspec'
+    command: sh -c 'cd .. && ./ci/test.sh'

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -140,21 +140,53 @@ module Rswag
         let(:mime) { 'application/json' }
         let(:json_example) do
           {
-            mime => {
               foo: 'bar'
-            }
           }
         end
         let(:api_metadata) { { response: {} } }
 
         before do
-          subject.examples(json_example)
+          subject.examples(mime => json_example)
         end
 
         it "adds to the 'response examples' metadata" do
           expect(api_metadata[:response][:content]).to match(
             mime => {
-              example: json_example[mime]
+              examples: {
+                example_0: {
+                  value: json_example
+                }
+              }
+            }
+          )
+        end
+      end
+
+      describe '#example(single)' do
+        let(:mime) { 'application/json' }
+        let(:summary) { "this is a summary"}
+        let(:description) { "this is an example description "}
+        let(:json_example) do
+          {
+              foo: 'bar'
+          }
+        end
+        let(:api_metadata) { { response: {} } }
+
+        before do
+          subject.example(mime, :example_key, json_example, summary, description)
+        end
+
+        it "adds to the 'response examples' metadata" do
+          expect(api_metadata[:response][:content]).to match(
+            mime => {
+              examples: {
+                example_key: {
+                  value: json_example,
+                  description: description,
+                  summary: summary
+                }
+              }
             }
           )
         end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -96,10 +96,25 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
 
         schema '$ref' => '#/definitions/blog'
 
+        #Legacy
         examples 'application/json' => {
+          id: 1,
+          title: 'Hello legay world!',
+          content: 'Hello legacy world and hello universe. Thank you all very much!!!',
+          thumbnail: 'legacy-thumbnail.png'
+        }
+
+        example 'application/json', :blog_example_1, {
           id: 1,
           title: 'Hello world!',
           content: 'Hello world and hello universe. Thank you all very much!!!',
+          thumbnail: 'thumbnail.png'
+        }, "Summary of the example", "A longer description of a fine blog post about a wonderfull universe!"
+
+        example 'application/json', :blog_example_2, {
+          id: 1,
+          title: 'Another fine example!',
+          content: 'Oh... what a fine example this is, indeed, a fine example!',
           thumbnail: 'thumbnail.png'
         }
 

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -221,11 +221,33 @@
             },
             "content": {
               "application/json": {
-                "example": {
-                  "id": 1,
-                  "title": "Hello world!",
-                  "content": "Hello world and hello universe. Thank you all very much!!!",
-                  "thumbnail": "thumbnail.png"
+                "examples": {
+                  "example_0": {
+                    "value": {
+                      "id": 1,
+                      "title": "Hello legay world!",
+                      "content": "Hello legacy world and hello universe. Thank you all very much!!!",
+                      "thumbnail": "legacy-thumbnail.png"
+                    }
+                  },
+                  "blog_example_1": {
+                    "value": {
+                      "id": 1,
+                      "title": "Hello world!",
+                      "content": "Hello world and hello universe. Thank you all very much!!!",
+                      "thumbnail": "thumbnail.png"
+                    },
+                    "summary": "Summary of the example",
+                    "description": "A longer description of a fine blog post about a wonderfull universe!"
+                  },
+                  "blog_example_2": {
+                    "value": {
+                      "id": 1,
+                      "title": "Another fine example!",
+                      "content": "Oh... what a fine example this is, indeed, a fine example!",
+                      "thumbnail": "thumbnail.png"
+                    }
+                  }
                 },
                 "schema": {
                   "$ref": "#/definitions/blog"


### PR DESCRIPTION
## Problem
* Examples are not showing because they have been moved in the later specification inside the mime type, and now have a new format (see link bellow)

## Solution
Started at #500 but took a bit more idealistic approach here into turning the `metadata` object already as close as possible to the OAS3 specification. As mentioned in #500, the `metadata` object is diverging quite a lot from the OAS specification, so this is already an attempt at bringing it back to as close to the final swagger document as possible.

Moves examples into the new OAS3 example specification

### This concerns this parts of the Open API Specification:
* https://swagger.io/specification/#example-object

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md
