### PR TITLE
FIX array query params for open api 3.0

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -125,20 +125,35 @@ module Rswag
 
         # OAS 3: https://swagger.io/docs/specification/serialization/
         if swagger_doc && doc_version(swagger_doc).start_with?('3') && param[:schema]
-          return "#{name}=#{value}" unless param[:schema][:type].to_sym == :object
-
           style = param[:style]&.to_sym || :form
           explode = param[:explode].nil? ? true : param[:explode]
 
-          case style
-          when :deepObject
-            return { name => value }.to_query
-          when :form
-            if explode
-              return value.to_query
-            else
-              return "#{CGI.escape(name.to_s)}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(',')
+          case param[:schema][:type].to_sym
+          when :object
+            case style
+            when :deepObject
+              return { name => value }.to_query
+            when :form
+              if explode
+                return value.to_query
+              else
+                return "#{CGI.escape(name.to_s)}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(',')
+              end
             end
+          when :array
+            case explode
+            when true
+              return value.to_a.flatten.map{|v| "#{CGI.escape(name.to_s)}=#{CGI.escape(v.to_s)}"}.join('&')
+            else
+              separator = case style
+                          when :form then ','
+                          when :spaceDelimited then '%20'
+                          when :pipeDelimited then '|'
+                          end
+              return "#{CGI.escape(name.to_s)}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(separator) 
+            end
+          else
+            return "#{name}=#{value}"
           end
         end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -180,6 +180,74 @@ module Rswag
           end
         end
 
+        context "'query' parameters of type 'object'" do
+          let(:id) { [3, 4, 5] }
+          let(:swagger_doc) { { swagger: '3.0' } }
+
+          before do
+            metadata[:operation][:parameters] = [
+              {
+                name: 'id', in: :query,
+                style: style,
+                explode: explode,
+                schema: { type: :array, items: { type: :integer } }
+              }
+            ]
+            allow(example).to receive(:id).and_return(id)
+          end
+
+          context 'form' do
+            let(:style) { :form }
+            context 'exploded' do
+              let(:explode) { true }
+              it 'formats as exploded form' do
+                expect(request[:path]).to eq('/blogs?id=3&id=4&id=5')
+              end
+            end
+
+            context 'not exploded' do
+              let(:explode) { false }
+              it 'formats as unexploded form' do
+                expect(request[:path]).to eq('/blogs?id=3,4,5')
+              end
+            end
+          end
+
+          context "spaceDelimited" do
+            let(:style) { :spaceDelimited }
+            context 'exploded' do
+              let(:explode) { true }
+              it 'formats as exploded form' do
+                expect(request[:path]).to eq('/blogs?id=3&id=4&id=5')
+              end
+            end
+
+            context 'not exploded' do
+              let(:explode) { false }
+              it 'formats as unexploded form' do
+                expect(request[:path]).to eq('/blogs?id=3%204%205')
+              end
+            end
+          end
+
+          context "pipeDelimited" do
+            let(:style) { :pipeDelimited }
+            context 'exploded' do
+              let(:explode) { true }
+              it 'formats as exploded form' do
+                expect(request[:path]).to eq('/blogs?id=3&id=4&id=5')
+              end
+            end
+
+            context 'not exploded' do
+              let(:explode) { false }
+              it 'formats as unexploded form' do
+                expect(request[:path]).to eq('/blogs?id=3|4|5')
+              end
+            end
+          end
+        end
+
         context "'header' parameters" do
           before do
             metadata[:operation][:parameters] = [{ name: 'Api-Key', in: :header, type: :string }]


### PR DESCRIPTION
## Problem
Array query params serialization is broken when working with openapi 3.0 due to recent updates [(PR link)](https://github.com/rswag/rswag/pull/311) to deepObject handling
Current serialization (regadless of any form or explode true/false):

```
"id=[\"3\", \"4", \"5" ]"
```

## Solution
I've updated the code and specs, so it reproduce what is describe on the open api docs
https://swagger.io/docs/specification/serialization/#:~:text=values%20get%20prefixed.-,Query%20Parameters,-Query%20parameters%20support

### This concerns this parts of the Open API Specification:
* https://swagger.io/docs/specification/serialization/#:~:text=values%20get%20prefixed.-,Query%20Parameters,-Query%20parameters%20support

### The changes I made are compatible with:
- [x] OAS2 (ish, doesn't break existing)
- [x] OAS3
- [x] OAS3.1

### Related Issues
described here
https://github.com/rswag/rswag/pull/311#issuecomment-1079095706

### Checklist
- [x] Added tests
- [ ] Changelog updated (not sure if I should update it)
- [ ] Added documentation to README.md
