### PR TITLE
Fix dynamic example generation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,16 +615,19 @@ end
 To enable examples generation from responses add callback above run_test! like:
 
 ```
-after do |example|
-  example.metadata[:response][:content]['application/json'][:examples] = {
-      example_1: {
-        value: JSON.parse(response.body, symbolize_names: true)
-        summary: "Summary (optional)"
-        description: "Description (Optional)"
+  after do |example|
+    content = example.metadata[:response][:content] || {}
+    example_spec = {
+      "application/json"=>{
+        examples: {
+          test_example: {
+            value: JSON.parse(response.body, symbolize_names: true)
+          }
+        }
       }
     }
-  }
-end
+    example.metadata[:response][:content] = content.deep_merge(example_spec)
+  end
 ```
 
 #### Dry Run Option ####


### PR DESCRIPTION
`example.metadata[:response][:content]` is not always initialised (if there's no other examples). There is a #TODO in the code to move the initialisation of `content` somewhere else, but this is just a quick fix in the documentation.