### PR TITLE
Fix for nullable refs

### DIFF
--- a/rswag-specs/lib/rswag/specs/extended_schema.rb
+++ b/rswag-specs/lib/rswag/specs/extended_schema.rb
@@ -7,14 +7,11 @@ module Rswag
     class ExtendedSchema < JSON::Schema::Draft4
       def initialize
         super
-        @attributes['type'] = ExtendedTypeAttribute
         @uri = URI.parse('http://tempuri.org/rswag/specs/extended_schema')
         @names = ['http://tempuri.org/rswag/specs/extended_schema']
       end
-    end
 
-    class ExtendedTypeAttribute < JSON::Schema::TypeV4Attribute
-      def self.validate(current_schema, data, fragments, processor, validator, options = {})
+      def validate(current_schema, data, *)
         return if data.nil? && (current_schema.schema['nullable'] == true || current_schema.schema['x-nullable'] == true)
 
         super

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -95,6 +95,84 @@ module Rswag
               it 'uses the referenced schema to validate the response body' do
                 expect { call }.to raise_error(/Expected response body/)
               end
+
+              context 'nullable referenced schema' do
+                let(:response) do
+                  OpenStruct.new(
+                    code: '200',
+                    headers: { 'X-Rate-Limit-Limit' => '10' },
+                    body: '{ "blog": null }'
+                  )
+                end
+
+                before do
+                  metadata[:response][:schema] = {
+                    properties: { blog: { '$ref' => '#/components/schema/blog' } },
+                    required: ['blog']
+                  }
+                end
+
+                context 'using x-nullable attribute' do
+                  before do
+                    metadata[:response][:schema][:properties][:blog]['x-nullable'] = true
+                  end
+
+                  context 'response matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+
+                context 'using nullable attrtibute' do
+                  before do
+                    metadata[:response][:schema][:properties][:blog]['nullable'] = true
+                  end
+
+                  context 'response matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+              end
+
+              context 'nullable oneOf wtih referenced schema' do
+                let(:response) do
+                  OpenStruct.new(
+                    code: '200',
+                    headers: { 'X-Rate-Limit-Limit' => '10' },
+                    body: '{ "blog": null }'
+                  )
+                end
+
+                before do
+                  metadata[:response][:schema] = {
+                    properties: {
+                      blog: {
+                        oneOf: [{ '$ref' => '#/components/schema/blog' }]
+                      }
+                    },
+                    required: ['blog']
+                  }
+                end
+
+                context 'using x-nullable attribute' do
+                  before do
+                    metadata[:response][:schema][:properties][:blog]['x-nullable'] = true
+                  end
+
+                  context 'response matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+
+                context 'using nullable attrtibute' do
+                  before do
+                    metadata[:response][:schema][:properties][:blog]['nullable'] = true
+                  end
+
+                  context 'response matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+              end
             end
 
             context 'deprecated definitions' do


### PR DESCRIPTION


Added a test to https://github.com/rswag/rswag/pull/332 

Not sure if you will agree with where I put the tests


> Previously the nullable check was only being applied to the type
> attribute validation, but schemas using anyOf, allOf, oneOf etc
> were unable to use nullable because they would never be passed
> directly to the field validator. This is crucial when using $ref
> combined with nullable, because these cases require the use of
> allOf.
> 
> The solution here is to simplify the validation extension at the root
> and not to attach the nullable handling to any particular attribute.
> 
> Before this change, the following would fail validation if foo was
> null:
> 
> ```json
> {
>   "type": "object",
>   "properties": {
>     "foo": {
>       "nullable": true,
>       "allOf": [
>         {
>           "$ref": "#/components/schemas/Foo"
>         }
>       ]
>     }
>   }
> }
> ```
> 
> With this change the nullable check is handled at the right spot
> before the allOf is evaluated.


