### PR TITLE
Tag the examples generated by run_test! for easier filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add query parameter serialization styles (OAS3) (https://github.com/rswag/rswag/pull/507)
 - Fix array parameter serialization on OAS3 (https://github.com/rswag/rswag/pull/507)
 - Rename generated `rswag-ui.rb` file to match Ruby style (https://github.com/rswag/rswag/pull/508)
+- Examples generated with `run_test!` now have the rspec tag `rswag` 
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ response '201', 'blog created' do
 end
 ```
 
-Also note that the examples generated with __run_test!__ are tagged with the `:rspec` so they can easily be filtered. E.g. `rspec --tag rswag`
+Also note that the examples generated with __run_test!__ are tagged with the `:rswag` so they can easily be filtered. E.g. `rspec --tag rswag`
 
 ### Null Values ###
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ response '201', 'blog created' do
 end
 ```
 
+Also note that the examples generated with __run_test!__ are tagged with the `:rspec` so they can easily be filtered. E.g. `rspec --tag rswag`
+
 ### Null Values ###
 
 This library is currently using JSON::Draft4 for validation of response models. Nullable properties can be supported with the non-standard property 'x-nullable' to a definition to allow null/nil values to pass. Or you can add the new standard ```nullable``` property to a definition.

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -106,7 +106,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response" do
+          it "returns a #{metadata[:response][:code]} response", rswag: true do
             assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
@@ -115,7 +115,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response" do |example|
+          it "returns a #{metadata[:response][:code]} response", rswag: true do |example|
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end


### PR DESCRIPTION
## Problem
rswag rspec examples aren't tagged, so in applications where there are a lot of request specs that aren't rswag specs a lot of time is wasted running those irrelevant specs.

## Solution
Tagging rspec examples allows for easy filtering in a custom rake task

### This concerns this parts of the Open API Specification:
N/A

### The changes I made are compatible with:
- [X] OAS2
- [X] OAS3
- [X] OAS3.1

### Related Issues
N/A

### Checklist
- [NA] Added tests
- [X] Changelog updated
- [X] Added documentation to README.md

### Steps to Test or Reproduce
cd test_app
rspec --tag rswag
