### PR TITLE
Update json-schema dependency version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Change default dev tooling setup to Ruby 2.7 and Rails 6 (https://github.com/rswag/rswag/pull/542)
 - Make the development docker user non-root for easier volume sharing (https://github.com/rswag/rswag/pull/550)
+- Update `json-schema` dependency version constraint (https://github.com/rswag/rswag/pull/517)
 
 ### Fixed
 

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 3.1', '< 7.1'
   s.add_dependency 'railties', '>= 3.1', '< 7.1'
-  s.add_dependency 'json-schema', '~> 2.2'
+  s.add_dependency 'json-schema', '>= 2.2', '< 4.0'
 end


### PR DESCRIPTION
## Problem
[json-schema](https://rubygems.org/gems/json-schema) dependency used in `rswag-specs` is outdated. This prevents already existing `json-schema` dependency in a project from being updated.

## Solution
Update [json-schema](https://rubygems.org/gems/json-schema) version constraint