### PR TITLE
Fix readme response header for open api 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,8 +575,8 @@ describe 'Blogs API' do
     post 'Creates a comment' do
 
       response 422, 'invalid request' do
-        header 'X-Rate-Limit-Limit', type: :integer, description: 'The number of allowed requests in the current period'
-        header 'X-Rate-Limit-Remaining', type: :integer, description: 'The number of remaining requests in the current period'
+        header 'X-Rate-Limit-Limit', schema: { type: :integer }, description: 'The number of allowed requests in the current period'
+        header 'X-Rate-Limit-Remaining', schema: { type: :integer }, description: 'The number of remaining requests in the current period'
   ...
 end
 ```


### PR DESCRIPTION
## Problem
OAS3 defines the response header needs to specify the schema, if you follow the example in the README, there will be a syntax error

## Solution
Update README.md

### This concerns this parts of the Open API Specification:
* [OPEN API SPECS RESPONSE OBJECT PAGE](https://spec.openapis.org/oas/v3.1.0#response-object)
* [OPEN API SPECS HEADER OBJECT PAGE](https://spec.openapis.org/oas/v3.1.0#header-object)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [x] Added documentation to README.md
