### PR TITLE
test(OpenAPIv3): Add more request factory specs

### DIFF
--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -121,6 +121,52 @@ module Rswag
           end
         end
 
+        context "'query' parameters of type 'array' by way of 'schema'" do
+          let(:swagger_doc) { { swagger: '3.0.3' } }
+
+          before do
+            metadata[:operation][:parameters] = [
+              { name: 'things', in: :query, schema: { type: :array }, collectionFormat: collection_format }
+            ]
+            allow(example).to receive(:things).and_return(['foo', 'bar'])
+          end
+
+          context 'collectionFormat = csv' do
+            let(:collection_format) { :csv }
+            it 'formats as comma separated values' do
+              expect(request[:path]).to eq('/blogs?things=foo,bar')
+            end
+          end
+
+          context 'collectionFormat = ssv' do
+            let(:collection_format) { :ssv }
+            it 'formats as space separated values' do
+              expect(request[:path]).to eq('/blogs?things=foo bar')
+            end
+          end
+
+          context 'collectionFormat = tsv' do
+            let(:collection_format) { :tsv }
+            it 'formats as tab separated values' do
+              expect(request[:path]).to eq('/blogs?things=foo\tbar')
+            end
+          end
+
+          context 'collectionFormat = pipes' do
+            let(:collection_format) { :pipes }
+            it 'formats as pipe separated values' do
+              expect(request[:path]).to eq('/blogs?things=foo|bar')
+            end
+          end
+
+          context 'collectionFormat = multi' do
+            let(:collection_format) { :multi }
+            it 'formats as multiple parameter instances' do
+              expect(request[:path]).to eq('/blogs?things=foo&things=bar')
+            end
+          end
+        end
+
         context "'query' parameters of type 'object'" do
           let(:things) { {'foo': 'bar'} }
           let(:swagger_doc) { { swagger: '3.0' } }


### PR DESCRIPTION
See https://github.com/rswag/rswag/pull/319. This PR is to prove that the functionality has since been implemented by including the tests of #319 without any of its code changes.

Signed-off-by: Andrew Kofink <akofink@atlassian.com>

## Problem
We are trying to determine if #319 is still needed.

## Solution
This PR adds only the tests from #319 to see if they pass with what's on master.

### This concerns this parts of the Open API Specification:
* https://swagger.io/specification/#parameter-object

### The changes I made are compatible with:
- [X] OAS2
- [X] OAS3
- [X] OAS3.1

### Related Issues
https://github.com/rswag/rswag/pull/319

### Checklist
- [X] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce
Testing will occur within the CI pipeline