### PR TITLE
Converted json only for post request

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -236,7 +236,7 @@ module Rswag
         if ['application/x-www-form-urlencoded', 'multipart/form-data'].include?(content_type)
           request[:payload] = build_form_payload(parameters, example)
         else
-          request[:payload] = build_json_payload(parameters, example)
+          request[:payload] = build_json_payload(parameters, example, verb = request[:verb])
         end
       end
 
@@ -251,14 +251,15 @@ module Rswag
         Hash[tuples]
       end
 
-      def build_json_payload(parameters, example)
+      def build_json_payload(parameters, example, verb = :post)
         body_param = parameters.select { |p| p[:in] == :body }.first
 
         return nil unless body_param
 
         raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
 
-        example.send(body_param[:name]).to_json
+        payload = example.send(body_param[:name])
+        verb == :post ? payload.to_json : payload
       end
 
       def doc_version(doc)


### PR DESCRIPTION
## Problem
For a GET request if we add a JSON body it gets added as a string in the params.

## Solution
Converted payload to JSON only in case of POST request and not for GET request.

### This concerns this parts of the Open API Specification:
* [LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
fixes #509 

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce
```
get 'sends JSON data' do
  consumes 'application/json'
  parameter name: :params, in: :body, schema: {
    type: :object,
    properties: {
      name: { type: :string }
    },
    required: ['name']
  }

  response 200, 'sends JSON payload in get' do
    let(:params) { { name: 'test' } }

    run_test!
  end
end
```

> This is my first PR in this repo and I am not sure if this is issue in rswag or actionpack, but this change found to be working for GET requests. Once changes are confirmed by team, will add test cases for same.
