### PR TITLE
Add spelling checks to the workflow in GitHub Actions

### DIFF
--- a/.github/workflows/spell_check.yml
+++ b/.github/workflows/spell_check.yml
@@ -1,0 +1,13 @@
+name: SpellCheck
+on:
+  - pull_request
+jobs:
+  codespell:
+    name: CodeSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: CodeSpell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true


### PR DESCRIPTION
## Problem
We want to run spell checking with CI.

## Solution
We would like to leave it to codespell to verify the spelling of our code.
I propose to use codespell-project/actions-codespell, now v1.0.
- https://github.com/codespell-project/actions-codespell

The following misspellings will result in failure:
![failure](https://user-images.githubusercontent.com/13041216/187050970-b650d2cd-2839-4963-964d-90860ae5aba6.png)


### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
- https://github.com/rswag/rswag/pull/535#pullrequestreview-1087762727

### Checklist
- [-] Added tests
- [-] Changelog updated
- [-] Added documentation to README.md