### PR TITLE
add spellchecking workflow to PRs

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,18 @@
+name: Spellchecking
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spellchecking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: streetsidesoftware/cspell-action@v2
+        with:
+          config: "./cspell.json"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Support for OpenAPI 3.0 ! [#286](https://github.com/rswag/rswag/pull/286)
 - Custom headers in rswag-api [#187](https://github.com/rswag/rswag/pull/187)
-- Allow document: false rspec metatag [#255](https://github.com/rswag/rswag/pull/255)
+- Allow document: false rspec meta-tag [#255](https://github.com/rswag/rswag/pull/255)
 - Add parameterized pattern for spec files [#254](https://github.com/rswag/rswag/pull/254)
 - Support Basic Auth on rswag-ui [#167](https://github.com/rswag/rswag/pull/167)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- cspell:ignore allof anyof oneof specifyingtesting -->
+
 rswag
 =========
 [![Build Status](https://github.com/rswag/rswag/actions/workflows/ruby.yml/badge.svg?branch=master)](https://github.com/rswag/rswag/actions/workflows/ruby.yml?query=branch%3Amaster+)
@@ -7,7 +9,7 @@ OpenApi 3.0 and Swagger 2.0 compatible!
 
 Seeking maintainers! Got a pet-bug that needs fixing? Just let us know in your issue/pr that you'd like to step up to help.
 
-Rswag extends rspec-rails "request specs" with a Swagger-based DSL for describing and testing API operations. You describe your API operations with a succinct, intuitive syntax, and it automatically runs the tests. Once you have green tests, run a rake task to auto-generate corresponding Swagger files and expose them as YAML or JSON endpoints. Rswag also provides an embedded version of the awesome [swagger-ui](https://github.com/swagger-api/swagger-ui) that's powered by the exposed file. This toolchain makes it seamless to go from integration specs, which youre probably doing in some form already, to living documentation for your API consumers.
+Rswag extends rspec-rails "request specs" with a Swagger-based DSL for describing and testing API operations. You describe your API operations with a succinct, intuitive syntax, and it automatically runs the tests. Once you have green tests, run a rake task to auto-generate corresponding Swagger files and expose them as YAML or JSON endpoints. Rswag also provides an embedded version of the awesome [swagger-ui](https://github.com/swagger-api/swagger-ui) that's powered by the exposed file. This toolchain makes it seamless to go from integration specs, which you're probably doing in some form already, to living documentation for your API consumers.
 
 Api Rswag creates [Swagger](http://swagger.io) tooling for Rails API's. Generate beautiful API documentation, including a UI to explore and test operations, directly from your rspec integration tests.
 
@@ -356,7 +358,7 @@ __NOTE:__ There is one difference between the official Markdown syntax and Swagg
 | ------- | ------- |
 | cell1   | cell2   |
 
-you should use the following syntax, making sure there are no whitespaces at the start of any of the lines:
+you should use the following syntax, making sure there is no whitespace at the start of any of the lines:
 
 ```
 &#13;
@@ -436,7 +438,7 @@ describe 'Auth examples API' do
 
       response '401', 'Invalid credentials' do
         let(:Authorization) { "Basic #{::Base64.strict_encode64('jsmith:jspass')}" }
-        let(:api_key) { 'barfoo' }
+        let(:api_key) { 'bar-foo' }
         run_test!
       end
     end
@@ -845,7 +847,7 @@ Rswag::Api.configure do |c|
 end
 ```
 
-Note how the filter is passed the rack env for the current request. This provides a lot of flexibilty. For example, you can assign the "host" property (as shown) or you could inspect session information or an Authorization header and remove operations based on user permissions.
+Note how the filter is passed the rack env for the current request. This provides a lot of flexibility. For example, you can assign the "host" property (as shown) or you could inspect session information or an Authorization header and remove operations based on user permissions.
 
 ### Custom Headers for Swagger Files ###
 

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,53 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "useGitignore": true,
+  "patterns": [
+    {
+      "name": "Url",
+      "pattern": "[\\w]+.com*[\\w]+"
+    },
+    {
+      "name": "QueryParam",
+      "pattern": "[?&][a-zA-z0-9_-|]+=[a-zA-Z0-9_-%]*"
+    }
+  ],
+  "ignoreRegExpList": [
+    "Url",
+    "QueryParam"
+  ],
+  "words": [
+    "actionpack",
+    "autoload",
+    "autoloadable",
+    "byebug",
+    "cacher",
+    "codegen",
+    "danielian",
+    "datetime",
+    "doctoc",
+    "domaindrivendev",
+    "fdescribe",
+    "fcontext",
+    "jsmith",
+    "jspass",
+    "geckodriver",
+    "libv8",
+    "openapi",
+    "pathing",
+    "railtie",
+    "railties",
+    "Rakefile",
+    "rdoc",
+    "rdoctask",
+    "rswag",
+    "srand",
+    "scrollbars",
+    "stylesheet",
+    "swaggerapi",
+    "swaggerize",
+    "tempuri",
+    "tmpdir",
+    "xlink"
+  ]
+}

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -78,7 +78,7 @@ module Rswag
       end
 
       def example(mime, name, value, summary=nil, description=nil)
-        # Todo - move initialization of metadatada somehwere else.
+        # Todo - move initialization of metadata somewhere else.
         if metadata[:response][:content].blank?
           metadata[:response][:content] = {}
         end

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -193,8 +193,8 @@ module Rswag
           tuples << ['Content-Type', content_type]
         end
 
-        # Rails test infrastructure requires rackified headers
-        rackified_tuples = tuples.map do |pair|
+        # Rails test infrastructure requires rack-formatted headers
+        rack_formatted_tuples = tuples.map do |pair|
           [
             case pair[0]
             when 'Accept' then 'HTTP_ACCEPT'
@@ -206,7 +206,7 @@ module Rswag
           ]
         end
 
-        request[:headers] = Hash[rackified_tuples]
+        request[:headers] = Hash[rack_formatted_tuples]
       end
 
       def add_payload(request, parameters, example)

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email       = ['domaindrivendev@gmail.com']
   s.homepage    = 'https://github.com/rswag/rswag'
   s.summary     = 'An OpenAPI-based (formerly called Swagger) DSL for rspec-rails & accompanying rake task for generating OpenAPI specification files'
-  s.description = 'Simplify API integration testing with a succinct rspec DSL and generate OpenAPI specification files directly from your rspecs. More about the OpenAPI initiative here: http://spec.openapis.org/'
+  s.description = 'Simplify API integration testing with a succinct rspec DSL and generate OpenAPI specification files directly from your rspec tests. More about the OpenAPI initiative here: http://spec.openapis.org/'
   s.license     = 'MIT'
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']

--- a/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
@@ -52,7 +52,7 @@ module Rswag
           allow(subject).to receive(:blog_id).and_return(1)
           allow(subject).to receive(:id).and_return(2)
           allow(subject).to receive(:q1).and_return('foo')
-          allow(subject).to receive(:api_key).and_return('fookey')
+          allow(subject).to receive(:api_key).and_return('fooKey')
           allow(subject).to receive(:blog).and_return(text: 'Some comment')
           allow(subject).to receive(:put)
           subject.submit_request(metadata)
@@ -60,7 +60,7 @@ module Rswag
 
         it "submits a request built from metadata and 'let' values" do
           expect(subject).to have_received(:put).with(
-            '/blogs/1/comments/2?q1=foo&api_key=fookey',
+            '/blogs/1/comments/2?q1=foo&api_key=fooKey',
             '{"text":"Some comment"}',
             { 'CONTENT_TYPE' => 'application/json' }
           )

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# cspell:ignore Bfoo Bbar
+
 require 'rswag/specs/request_factory'
 
 module Rswag
@@ -557,7 +559,7 @@ module Rswag
             allow(example).to receive(:api_key).and_return('foobar')
           end
 
-          it 'applieds the scheme by default' do
+          it 'applies the scheme by default' do
             expect(request[:path]).to eq('/blogs?api_key=foobar')
           end
         end

--- a/test-app/spec/integration/auth_tests_spec.rb
+++ b/test-app/spec/integration/auth_tests_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' 
       end
 
       response '401', 'Invalid credentials' do
-        let(:api_key) { 'barfoo' }
+        let(:api_key) { 'barFoo' }
         run_test!
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' 
 
       response '401', 'Invalid credentials' do
         let(:Authorization) { "Basic #{::Base64.strict_encode64('jsmith:jspass')}" }
-        let(:api_key) { 'barfoo' }
+        let(:api_key) { 'barFoo' }
         run_test!
       end
     end

--- a/test-app/spec/rails_helper.rb
+++ b/test-app/spec/rails_helper.rb
@@ -33,11 +33,11 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
+  # RSpec Rails can automatically mix in different behaviors to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.
   #
-  # You can disable this behaviour by removing the line below, and instead
+  # You can disable this behavior by removing the line below, and instead
   # explicitly tag your specs with their type, e.g.:
   #
   #     RSpec.describe UsersController, :type => :controller do


### PR DESCRIPTION
- add automatic spellchecking to PRs
- add a dictionary to deal with false-positives
- fix any actual issues
- use the default American spelling otherwise we'll keep having to update the dictionary with English equivalents (eg. behavior vs behaviour)