### PR TITLE
Update base path configuration for OpenAPI 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Fix Style/SingleArgumentDig issue in `swagger_formatter` (https://github.com/rswag/rswag/pull/486)
+- Fix Style/SingleArgumentDig issue in `swagger_formatter` (https://github.com/rswag/rswag/pull/486)
+- Fix base path for OAS3 specification (https://github.com/rswag/rswag/pull/547)
 
 ### Documentation
 
@@ -25,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Examples generated with `run_test!` now have the rspec tag `rswag` 
+- Examples generated with `run_test!` now have the rspec tag `rswag`
 - Add query parameter serialization styles (OAS3) (https://github.com/rswag/rswag/pull/507)
 - Support for adding descriptions in body params (https://github.com/rswag/rswag/pull/422)
 - Display all validation errors instead of only the first (https://github.com/rswag/rswag/pull/461)

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -129,11 +129,17 @@ module Rswag
       end
 
       def base_path_from_servers(swagger_doc)
-        if swagger_doc[:servers].count == 1
-          URI(swagger_doc[:servers].first[:url]).path
-        else
-          URI(swagger_doc[:servers].first[:url]).path
+        return '' unless swagger_doc.has_key?(:servers)
+
+        server = swagger_doc[:servers].firstt
+
+        variables = {}
+        server[:variables].each_pair do |k,v|
+          variables[k] = v[:default]
         end
+
+        url = server[:url].gsub(/\{(.*?)\}/) { variables[$1.to_sym]  }
+        URI(url).path
       end
 
       def build_query_string_part(param, value, swagger_doc)

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -131,7 +131,7 @@ module Rswag
       def base_path_from_servers(swagger_doc)
         return '' unless swagger_doc.has_key?(:servers)
 
-        server = swagger_doc[:servers].firstt
+        server = swagger_doc[:servers].first
 
         variables = {}
         server[:variables].each_pair do |k,v|

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -134,7 +134,7 @@ module Rswag
         server = swagger_doc[:servers].first
 
         variables = {}
-        server[:variables].each_pair do |k,v|
+        server.fetch(:variables, {}).each_pair do |k,v|
           variables[k] = v[:default]
         end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -536,11 +536,44 @@ module Rswag
           end
         end
 
-        context 'global basePath' do
-          before { swagger_doc[:basePath] = '/api' }
+        context 'base path' do
+          context 'openapi 2.0' do
+            before { swagger_doc[:basePath] = '/api' }
 
-          it 'prepends to the path' do
-            expect(request[:path]).to eq('/api/blogs')
+            it 'prepends to the path' do
+              expect(request[:path]).to eq('/api/blogs')
+            end
+          end
+
+          context 'openapi 3.0' do
+            before do
+              swagger_doc[:servers] = [{
+                :url => "https://{defaultHost}",
+                :variables => {
+                  :defaultHost => {
+                    :default => "www.example.com"
+                  }
+                }
+              }]
+            end
+
+            it 'generates the path' do
+              expect(request[:path]).to eq('/blogs')
+            end
+          end
+
+          context 'openapi 3.0 with old config' do
+            let(:swagger_doc) { {:openapi => '3.0', :basePath => '/blogs' } }
+
+            before do
+              allow(ActiveSupport::Deprecation).to receive(:warn)
+            end
+
+            it 'generates the path' do
+              expect(request[:headers]).to eq({})
+              expect(ActiveSupport::Deprecation).to have_received(:warn)
+                .with('Rswag::Specs: WARNING: basePath is replaced in OpenAPI3! Update your swagger_helper.rb')
+            end
           end
         end
 


### PR DESCRIPTION
## Problem

API Host and base URL definition has changed from OAS2 to OAS3.

`schemes`, `host` and `basePath` definitions are being replaced by [Server Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-object)

This is causing issue https://github.com/rswag/rswag/issues/318.

Closes https://github.com/rswag/rswag/pull/397
Closes https://github.com/rswag/rswag/issues/318

## Solution

I'm building on top of @developingchris's approach from https://github.com/rswag/rswag/pull/397.
The solution is to parse the URL from the Server Object.

### This concerns this parts of the Open API Specification:
* [OAS2.0: API Server and Base URL](https://swagger.io/docs/specification/2-0/api-host-and-base-path/)
* [OAS3.0: API Server and Base URL](https://swagger.io/docs/specification/api-host-and-base-path/)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
- https://github.com/rswag/rswag/issues/318

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] ~Added~ documentation to README.md

### Steps to Test or Reproduce

see https://github.com/rswag/rswag/issues/318