### PR TITLE
update ChangeLog to replect contents of latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fixes examples for OAS3 specification, allowing multiple examples (https://github.com/rswag/rswag/pull/501)
-- Add query parameter serialization styles (OAS3) (https://github.com/rswag/rswag/pull/507)
-- Fix array parameter serialization on OAS3 (https://github.com/rswag/rswag/pull/507)
-- Rename generated `rswag-ui.rb` file to match Ruby style (https://github.com/rswag/rswag/pull/508)
-- Examples generated with `run_test!` now have the rspec tag `rswag` 
+
+### Added
 
 ### Changed
+
+- Change default dev tooling setup to Ruby 2.7 and Rails 6 (https://github.com/rswag/rswag/pull/542)
+
+### Fixed
+
+### Documentation
+
+
+## [2.6.0] - 2022-09-09
+
+### Added
+
+- Examples generated with `run_test!` now have the rspec tag `rswag` 
+- Add query parameter serialization styles (OAS3) (https://github.com/rswag/rswag/pull/507)
+- Support for adding descriptions in body params (https://github.com/rswag/rswag/pull/422)
+- Display all validation errors instead of only the first (https://github.com/rswag/rswag/pull/461)
+
+## Fixed
+
+- Fixes examples for OAS3 specification, allowing multiple examples (https://github.com/rswag/rswag/pull/501)
+- Fix array parameter serialization on OAS3 (https://github.com/rswag/rswag/pull/507)
+- Fix assorted spelling errors (https://github.com/rswag/rswag/pull/535)
+- Fix null-checking when using a referenced property (https://github.com/rswag/rswag/pull/515)
+
+### Changed
+
+- Rename generated `rswag-ui.rb` file to match Ruby style (https://github.com/rswag/rswag/pull/508)
+- Code comment formatting changes (https://github.com/rswag/rswag/pull/487)
+
+### Documentation
+
+- Add Syntax Highlighting to ReadMe (https://github.com/rswag/rswag/pull/525/files)
+- Fix ReadMe response headers example for OpenApi3.0 (https://github.com/rswag/rswag/pull/518)
+- Update TOC in the ReadMe (https://github.com/rswag/rswag/pull/536/files)
+- Fix incorrect sample code for example generation (https://github.com/rswag/rswag/pull/513)
 
 ## [2.5.1] - 2022-02-10
 


### PR DESCRIPTION
Probably should've done this before release 2.6.0 but I forgot it existed because I'm so used to the GH Releases notes :sweat_smile: 