### PR TITLE
Make the docker user non-root for easier volume sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Change default dev tooling setup to Ruby 2.7 and Rails 6 (https://github.com/rswag/rswag/pull/542)
+- Make the development docker user non-root for easier volume sharing (https://github.com/rswag/rswag/pull/550)
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,18 @@ FROM ruby:2.7
 ENV RAILS_VERSION 7.0.3.1
 
 RUN apt-get update -qq && apt-get install -y nodejs npm
-WORKDIR /rswag
-COPY . /rswag
-
+# Bugfix for https://github.com/rubyjs/mini_racer/issues/220#issuecomment-1010724771
 RUN gem update --system
+
+# Run docker as a non-root user to avoid having to chown generated files while developing
+ENV APP_PATH=/rswag/
+ENV BUNDLE_PATH=/usr/local/bundle
+ARG USER_ID=1000
+RUN useradd -md ${APP_PATH} appuser -u ${USER_ID} && chown appuser:appuser ${APP_PATH}
+USER appuser
+WORKDIR ${APP_PATH}
+
+COPY --chown=appuser:appuser . ${APP_PATH}
 RUN "./ci/build.sh"
 
 # Configure the main process to run when running the image

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+default: build
+
+build:
+	docker compose build --build-arg=USER_ID=$(shell id -u)

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
   ],
   "words": [
     "actionpack",
+    "appuser",
     "autoload",
     "autoloadable",
     "byebug",


### PR DESCRIPTION
The `swagger.json`/`Gemfile.lock` files generated inside of the test-app are created by the docker user. The docker user is root by default. When using docker-compose volumes to share files between the host & the container, the generated file retains the root docker user as the owner. This prevents any edits from being made to those files locally without using either `sudo` or `sudo chown`.

The solution is to set the container user id to match your own user id. Typically you'll be `USER_ID=1000` on your own machine, and you can double check that using `$ id -u`.
If your user id differs, then `docker build --build-arg USER_ID=$(id -u) .` will pass your id into the docker container build.