### PR TITLE
add deprecation notices for EOL Ruby & RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Change default dev tooling setup to Ruby 2.7 and Rails 6 (https://github.com/rswag/rswag/pull/542)
 - Make the development docker user non-root for easier volume sharing (https://github.com/rswag/rswag/pull/550)
+- Add deprecation notice for intent to drop support for Ruby 2.6 and RSpec 2 (https://github.com/rswag/rswag/pull/552)
 
 ### Fixed
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -3,6 +3,8 @@
 module Rswag
   module Specs
     module ExampleGroupHelpers
+      ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for Ruby 2.6 will be dropped in v3.0') if RUBY_VERSION.start_with? '2.6'
+
       def path(template, metadata = {}, &block)
         metadata[:path_item] = { template: template }
         describe(template, metadata, &block)
@@ -100,8 +102,8 @@ module Rswag
       end
 
       def run_test!(&block)
-        # NOTE: rspec 2.x support
         if RSPEC_VERSION < 3
+          ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
           before do
             submit_request(example.metadata)
           end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support'
+
 module Rswag
   module Specs
     module ExampleGroupHelpers

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -7,10 +7,12 @@ require 'swagger_helper'
 module Rswag
   module Specs
     class SwaggerFormatter < ::RSpec::Core::Formatters::BaseTextFormatter
+      ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for Ruby 2.6 will be dropped in v3.0') if RUBY_VERSION.start_with? '2.6'
 
-      # NOTE: rspec 2.x support
       if RSPEC_VERSION > 2
         ::RSpec::Core::Formatters.register self, :example_group_finished, :stop
+      else
+        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
       end
 
       def initialize(output, config = Rswag::Specs.config)
@@ -21,7 +23,6 @@ module Rswag
       end
 
       def example_group_finished(notification)
-        # NOTE: rspec 2.x support
         metadata = if RSPEC_VERSION > 2
           notification.group.metadata
         else

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -11,10 +11,10 @@ namespace :rswag do
         'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
       )
 
-      # NOTE: rspec 2.x support
       if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.swagger_dry_run
         t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined']
       else
+        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
         t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--order defined']
       end
     end


### PR DESCRIPTION
The coverage reports in #551 show that our biggest gaps are for RSpec2 specific methods.
[The last RSpec 2.X release was back in 2014-06-01](https://relishapp.com/rspec/rspec-core/v/2-99/docs/changelog) and [Ruby2.6 EOL happened on March 31 2022](https://endoflife.date/ruby). 
The easiest solution is to just drop support for the old versions.

Dropping support for them is technically a breaking change, so I've added deprecation notices when those versions are detected.
We should probably drop support for Rails 5 as well since it's EOL, but I haven't found how to detect the Rails version yet :thinking: 