### PR TITLE
make rspec-core dependency explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-* Fix Style/SingleArgumentDig issue in `swagger_formatter` (https://github.com/rswag/rswag/pull/486)
+- Fix Style/SingleArgumentDig issue in `swagger_formatter` (https://github.com/rswag/rswag/pull/486)
+- Make dependency on rspec-core explicit instead of implied (https://github.com/rswag/rswag/pull/554)
 
 ### Documentation
 

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.1', '< 7.1'
   s.add_dependency 'railties', '>= 3.1', '< 7.1'
   s.add_dependency 'json-schema', '>= 2.2', '< 4.0'
+  s.add_dependency 'rspec-core', '>=2.14'
 end


### PR DESCRIPTION
## Problem
See #308 for description

## Solution

Make dependency on `rspec-core` explicit instead of implied by the package contents

### Related Issues

Closes #308 

### Checklist
- :x:  Added tests
- :heavy_check_mark:  Changelog updated
- :x:  Added documentation to README.md

### Steps to Test or Reproduce

See #308 for steps to reproduce
