### PR TITLE
Request body examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fix request body examples (https://github.com/rswag/pull/555)
 - Fix Style/SingleArgumentDig issue in `swagger_formatter` (https://github.com/rswag/rswag/pull/486)
 - Make dependency on rspec-core explicit instead of implied (https://github.com/rswag/rswag/pull/554)
 - Fix base path for OAS3 specification (https://github.com/rswag/rswag/pull/547)

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -56,14 +56,14 @@ module Rswag
       end
 
 
-      def request_body_example(name:, summary:, value:, mime:) 
+      def request_body_example(value:, summary: nil, name: nil) 
         if metadata.key?(:operation) 
-          metadata[:operation][:request_examples] ||= {}
-          metadata[:operation][:request_examples][mime] ||= {}
-          metadata[:operation][:request_examples][mime][name] = {
-            value: value, 
-            summary: summary,
-          }
+          metadata[:operation][:request_examples] ||= []
+          example = { value: value } 
+          example[:summary] = summary if summary 
+          # We need the examples to have a unique name for a set of examples, so just make the name the length if one isn't provided.
+          example[:name] = name || metadata[:operation][:request_examples].length()
+          metadata[:operation][:request_examples] << example
         end 
       end 
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -55,6 +55,18 @@ module Rswag
         end
       end
 
+
+      def request_body_example(name:, summary:, value:, mime:) 
+        if metadata.key?(:operation) 
+          metadata[:operation][:request_examples] ||= {}
+          metadata[:operation][:request_examples][mime] ||= {}
+          metadata[:operation][:request_examples][mime][name] = {
+            value: value, 
+            summary: summary,
+          }
+        end 
+      end 
+
       def response(code, description, metadata = {}, &block)
         metadata[:response] = { code: code, description: description }
         context(description, metadata, &block)

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -63,7 +63,12 @@ module Rswag
                     value[:requestBody][:required] = true if schema_param[:required]
                     value[:requestBody][:description] = schema_param[:description] if schema_param[:description]
                     mime_list.each do |mime|
+
                       value[:requestBody][:content][mime] = { schema: schema_param[:schema] }
+                      examples = value.dig(:request_examples, mime)
+                      if examples
+                        value[:requestBody][:content][mime][:examples] = examples
+                      end
                     end
                   end
 
@@ -200,6 +205,7 @@ module Rswag
         is_hash = value.is_a?(Hash)
         value.delete(:consumes) if is_hash && value[:consumes]
         value.delete(:produces) if is_hash && value[:produces]
+        value.delete(:request_examples) if is_hash && value[:request_examples]
       end
     end
   end

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -62,12 +62,17 @@ module Rswag
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     value[:requestBody][:required] = true if schema_param[:required]
                     value[:requestBody][:description] = schema_param[:description] if schema_param[:description]
+                    examples = value.dig(:request_examples)
                     mime_list.each do |mime|
-
                       value[:requestBody][:content][mime] = { schema: schema_param[:schema] }
-                      examples = value.dig(:request_examples, mime)
                       if examples
-                        value[:requestBody][:content][mime][:examples] = examples
+                        value[:requestBody][:content][mime][:examples] ||= {}
+                        examples.map do |example|
+                          value[:requestBody][:content][mime][:examples][example[:name]] = {
+                            summary: example[:summary] || value[:summary],
+                            value: example[:value]
+                          }
+                        end
                       end
                     end
                   end

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -136,6 +136,38 @@ module Rswag
         end
       end
 
+      describe '#request_body_example(value:, summary: nil, name: nil)' do 
+        context "when adding one example" do 
+          before { subject.request_body_example(value: value)}
+          let(:api_metadata) { { operation: {} } }
+          let(:value) { { field: 'A', another_field: 'B' } }
+
+          it "assigns the example to the metadata" do 
+            expect(api_metadata[:operation][:request_examples].length()).to eq(1) 
+            expect(api_metadata[:operation][:request_examples][0]).to eq({ value: value, name: 0 })
+          end 
+        end
+
+        context "when adding multiple examples with additional information" do 
+          before { 
+            subject.request_body_example(value: example_one)
+            subject.request_body_example(value: example_two, name: example_two_name, summary: example_two_summary)
+          }
+          let(:api_metadata) { { operation: {} } }
+          let(:example_one) { { field: 'A', another_field: 'B' } }
+          let(:example_two) { { field: 'B', another_field: 'C' } }
+          let(:example_two_name) { 'example_two' }
+          let(:example_two_summary) { 'An example description' }
+
+          it "assigns all examples to the metadata" do 
+            expect(api_metadata[:operation][:request_examples].length()).to eq(2) 
+            expect(api_metadata[:operation][:request_examples][0]).to eq({ value: example_one, name: 0 })
+            expect(api_metadata[:operation][:request_examples][1]).to eq({ value: example_two, name: example_two_name, summary: example_two_summary })
+          end 
+        end  
+      end 
+
+
       describe '#examples(example)' do
         let(:mime) { 'application/json' }
         let(:json_example) do


### PR DESCRIPTION
## Problem
Closes https://github.com/rswag/rswag/issues/380

## Solution
Cherry-picking @kriston-costa's solution from https://github.com/instacart/rswag/pull/4

### This concerns this parts of the Open API Specification:
* [Request Body Examples](https://spec.openapis.org/oas/v3.1.0#request-body-examples)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues

- https://github.com/rswag/rswag/issues/380
- https://github.com/instacart/rswag/pull/4/files

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce

```ruby
# spec/integration/blogs_spec.rb
describe 'Blogs API' do
  path '/blogs/{blog_id}' do
    get 'Retrieves a blog' do
      request_example value: { some_field: 'Foo' }, name: 'request_example_1', summary: 'A request example'
      response 200, 'blog found' do
        ...
```
