### PR TITLE
Add ADDITIONAL_RSPEC_OPTS ENV var for rswag:specs:swaggerize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add tooling for measuring test coverage so that changes are safer (https://github.com/rswag/rswag/pull/551)
 - Add CSP compatible with rswag in case the Rails one is not compatible (https://github.com/rswag/rswag/pull/263)
+- Add ADDITIONAL_RSPEC_OPTS env variable (https://github.com/rswag/rswag/pull/556)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -484,6 +484,15 @@ By default, rswag will search for integration tests in _spec/requests_, _spec/ap
 rake rswag:specs:swaggerize PATTERN="spec/swagger/**/*_spec.rb"
 ```
 
+### Additional rspec options
+
+You can add additional rspec parameters using the ADDITIONAL_RSPEC_OPTS env variable:
+
+```ruby
+# Only include tests tagged "rswag"
+rake rswag:specs:swaggerize ADDITIONAL_RSPEC_OPTS="--tag rswag"
+```
+
 ### Referenced Parameters and Schema Definitions ###
 
 Swagger allows you to describe JSON structures inline with your operation descriptions OR as referenced globals.

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -11,8 +11,13 @@ namespace :rswag do
         'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
       )
 
+      additional_rspec_opts = ENV.fetch(
+        'ADDITIONAL_RSPEC_OPTS',
+        ''
+      )
+
       if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.swagger_dry_run
-        t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined']
+        t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined'] << additional_rspec_opts
       else
         ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
         t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--order defined']


### PR DESCRIPTION
This allows easier filtering of rswag specs that are intermingled with non-rswag specs. For example, if run_test! is used consistently, then one can do the following to run only the rswag specs.

ADDITIONAL_RSPEC_OPTS='--tag rswag'
rake rswag:specs:swaggerize

## Problem
In my work repository, rswag specs are intermingled with non-rswag specs in the `requests` subfolder. The non-rswag specs are run along side the rswag specs with `rake rswag:specs:swaggerize` and slows down document generation quite a bit, running irrelevant tests.

## Solution
Allow passing additional rspec options via ENV variable so that only the rswag specs can be run.