### PR TITLE
chore: Update Url and QueryParam in cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -5,11 +5,11 @@
   "patterns": [
     {
       "name": "Url",
-      "pattern": "[\\w]+.com*[\\w]+"
+      "pattern": "/\\b\\w+\\.(com|org)(\\/[\\w.-]+)*?/g"
     },
     {
       "name": "QueryParam",
-      "pattern": "[?&][a-zA-z0-9_-|]+=[a-zA-Z0-9_-%]*"
+      "pattern": "/[?&][a-zA-z0-9_|-]+=[a-zA-Z0-9_%-]*/g"
     }
   ],
   "ignoreRegExpList": [


### PR DESCRIPTION
## Problem

There were some issues with the spell checker patterns.


These might do a better job of matching URLs.

The `.com*` would match anything with `co`

![image](https://user-images.githubusercontent.com/3740137/193091677-4f60c13f-9a00-4d83-8f8a-d64c580a0ca1.png)

See: https://regex101.com/r/2Hx7dM/1

Note: the built in `Urls` pattern will catch most `https` urls.

