### PR TITLE
Fix parameters with schema reference

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -148,7 +148,7 @@ module Rswag
           style = param[:style]&.to_sym || :form
           explode = param[:explode].nil? ? true : param[:explode]
 
-          case param[:schema][:type].to_sym
+          case param[:schema][:type]&.to_sym
           when :object
             case style
             when :deepObject

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -182,7 +182,7 @@ module Rswag
           end
         end
 
-        context "'query' parameters of type 'object'" do
+        context "'query' parameters of type 'array'" do
           let(:id) { [3, 4, 5] }
           let(:swagger_doc) { { swagger: '3.0' } }
 
@@ -247,6 +247,25 @@ module Rswag
                 expect(request[:path]).to eq('/blogs?id=3|4|5')
               end
             end
+          end
+        end
+
+        context "'query' parameters with schema reference" do
+          let(:things) { 'foo' }
+          let(:swagger_doc) { { swagger: '3.0' } }
+
+          before do
+            metadata[:operation][:parameters] = [
+              {
+                name: 'things', in: :query,
+                schema: { '$ref' => '#/components/schemas/FooType' }
+              }
+            ]
+            allow(example).to receive(:things).and_return(things)
+          end
+
+          it 'builds the query string' do
+            expect(request[:path]).to eq('/blogs?things=foo')
           end
         end
 


### PR DESCRIPTION
## Problem
Reading https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject it says that `schema` can be a "Schema Object" or a "Reference Object".

I think the code on `rswag/specs/request_factory.rb` is not prepared for the "Reference Object" option. When `schema` has a `$ref` and not a `type` it raises an exception:
```
NoMethodError:
   undefined method `to_sym' for nil:NilClass

             case param[:schema][:type].to_sym
                                       ^^^^^^^
``` 

## Solution
Don't raise an exception, and instead add a fallback as we had before version `2.6.0`.


### This concerns this parts of the Open API Specification:
* [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject )

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [ ] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/563

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
