### PR TITLE
Correct method name in README example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix request body examples (https://github.com/rswag/pull/555)
+- Corrected method name in README example (https://github.com/rswag/rswag/pull/566)
 - Fix Style/SingleArgumentDig issue in `swagger_formatter` (https://github.com/rswag/rswag/pull/486)
 - Make dependency on rspec-core explicit instead of implied (https://github.com/rswag/rswag/pull/554)
 - Fix base path for OAS3 specification (https://github.com/rswag/rswag/pull/547)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ There is also a generator which can help get you started `rails generate rspec:s
           tags 'Blogs', 'Another Tag'
           produces 'application/json', 'application/xml'
           parameter name: :id, in: :path, type: :string
-          request_example value: { some_field: 'Foo' }, name: 'basic', summary: 'Request example description'
+          request_body_example value: { some_field: 'Foo' }, name: 'basic', summary: 'Request example description'
 
           response '200', 'blog found' do
             schema type: :object,
@@ -586,7 +586,7 @@ describe 'Blogs API' do
 
     get 'Retrieves a blog' do
 
-      request_example value: { some_field: 'Foo' }, name: 'request_example_1', summary: 'A request example'
+      request_body_example value: { some_field: 'Foo' }, name: 'request_example_1', summary: 'A request example'
 
       response 200, 'blog found' do
         ...


### PR DESCRIPTION
## Problem
Incorrect method name used in example (see https://github.com/rswag/rswag/pull/555#discussion_r1004437990)

## Solution
Changing `request_example` to `request_body_example`

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
- https://github.com/rswag/rswag/pull/555

### Checklist
- ~Added tests~
- [x] Changelog updated
- [x] Added documentation to README.md
