### PR TITLE
Allow Host header setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add tooling for measuring test coverage so that changes are safer (https://github.com/rswag/rswag/pull/551)
 - Add CSP compatible with rswag in case the Rails one is not compatible (https://github.com/rswag/rswag/pull/263)
 - Add ADDITIONAL_RSPEC_OPTS env variable (https://github.com/rswag/rswag/pull/556)
+- Add option to set Host header (https://github.com/rswag/rswag/pull/184)
 
 ### Changed
 

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -213,14 +213,23 @@ module Rswag
           tuples << ['Content-Type', content_type]
         end
 
+
+        # Host header
+        host = metadata[:operation][:host] || swagger_doc[:host]
+        if host.present?
+          host = example.respond_to?(:'Host') ? example.send(:'Host') : host
+          tuples << ['Host', host]
+        end
+
         # Rails test infrastructure requires rack-formatted headers
         rack_formatted_tuples = tuples.map do |pair|
           [
             case pair[0]
-            when 'Accept' then 'HTTP_ACCEPT'
-            when 'Content-Type' then 'CONTENT_TYPE'
-            when 'Authorization' then 'HTTP_AUTHORIZATION'
-            else pair[0]
+              when 'Accept' then 'HTTP_ACCEPT'
+              when 'Content-Type' then 'CONTENT_TYPE'
+              when 'Authorization' then 'HTTP_AUTHORIZATION'
+              when 'Host' then 'HTTP_HOST'
+              else pair[0]
             end,
             pair[1]
           ]

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -213,7 +213,6 @@ module Rswag
           tuples << ['Content-Type', content_type]
         end
 
-
         # Host header
         host = metadata[:operation][:host] || swagger_doc[:host]
         if host.present?

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -383,6 +383,28 @@ module Rswag
           end
         end
 
+        context 'host header' do
+          context "explicit 'Host' value provided" do
+            before do
+              metadata[:operation][:host] = 'swagger.io'
+            end
+
+            it "sets 'Host' header" do
+              expect(request[:headers]).to eq('HTTP_HOST' => 'swagger.io')
+            end
+          end
+
+          context "no 'Host' value provided" do
+            before do
+              metadata[:operation][:host] = nil
+            end
+
+            it "does not set 'Host' header" do
+              expect(request[:headers]).to eq({})
+            end
+          end
+        end
+
         context 'basic auth' do
           context 'swagger 2.0' do
             before do


### PR DESCRIPTION
## Problem
Missing option to set `Host` header.

Closes: https://github.com/rswag/rswag/pull/184.

## Solution

There already is reviewed solution in https://github.com/rswag/rswag/pull/184.
This PR only adds test coverage to help the changes get merged.

### This concerns this parts of the Open API Specification:

-

### The changes I made are compatible with:
- [x] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
- https://github.com/rswag/rswag/pull/184
 
### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce

...
