### PR TITLE
docs: Update template to ask for dependency versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,10 +21,14 @@ If applicable, add screenshots to help explain your problem.
 ## Additional context
 Add any other context about the problem here.
 
-## Rswag Version
-The version of rswag are you using.
+## Dependency versions
+The version of are you using for:
+* Rswag:
+* RSpec:
+* Rails:
+* Ruby:
 
-## Relates to which version of OAS (Open API Specification)
+## Relates to which version of OAS (OpenAPI Specification)
 - [ ] OAS2
 - [ ] OAS3
 - [ ] OAS3.1

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,7 +13,7 @@ A clear and concise description of what the problem is.
 A clear and concise description of what you want to happen.
 
 ## What support could we give you, so you could implement this yourself?
-Please tell us how could we help you implement this feature, so you could 
+Please tell us how could we help you implement this feature, so you could
 become a contributor. **Our time is limited, so it's unlikely that we will
 be able to implement this ourselves, but we will try to help you**
 
@@ -23,7 +23,7 @@ A clear and concise description of any alternative solutions or features you've 
 ## Additional context
 Add any other context or screenshots about the feature request here.
 
-## Relates to which version of OAS (Open API Specification)
+## Relates to which version of OAS (OpenAPI Specification)
 - [ ] OAS2
 - [ ] OAS3
 - [ ] OAS3.1

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@ A clear and concise description of what the problem is.
 ## Solution
 A clear and concise description of what the solution is.
 
-### This concerns this parts of the Open API Specification:
-* [LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
+### This concerns this parts of the OpenAPI Specification:
+* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
 * [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)
 
 ### The changes I made are compatible with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Documentation
 
+- Ask for dependency versions in issue template (https://github.com/rswag/rswag/pull/575)
+
 ## [2.8.0]
 
 ### Added
@@ -52,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fix request body examples (https://github.com/rswag/pull/555)
+- Fix request body examples (https://github.com/rswag/rswag/pull/555)
 - Corrected method name in README example (https://github.com/rswag/rswag/pull/566)
 - Fix Style/SingleArgumentDig issue in `swagger_formatter` (https://github.com/rswag/rswag/pull/486)
 - Make dependency on rspec-core explicit instead of implied (https://github.com/rswag/rswag/pull/554)

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -147,7 +147,7 @@ module Rswag
 
         target_node[:content] ||= {}
         mime_list.each do |mime_type|
-          # TODO upgrade to have content-type specific schema
+          # TODO: upgrade to have content-type specific schema
           (target_node[:content][mime_type] ||= {}).merge!(schema: schema)
         end
       end


### PR DESCRIPTION
Suggestion to ask contributors for more of their environment.

Also, adding a few minor changes in comments/texts. No change that would influence behavior.

## Problem
Could be easier to ask for package versions right away.

## Solution
Add field to note package versions into issue template.

(using the list of dependencies requested at https://github.com/rswag/rswag/issues/559#issuecomment-1261202414)

### This concerns this parts of the Open API Specification:
-

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
-

### Checklist
- [ ] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce
-