### PR TITLE
Allow `responses` global key alongside `definitions` for swagger 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Make dependency on rspec-core explicit instead of implied (https://github.com/rswag/rswag/pull/554)
 - Fix base path for OAS3 specification (https://github.com/rswag/rswag/pull/547)
 - Fix ResponseValidator adding support for nullable and required headers (https://github.com/rswag/rswag/pull/527)
+- Fix inability to define common responses in the global responses section and reference that definition via $ref at the operation level in swagger 2.0
 
 ### Documentation
 

--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -72,7 +72,7 @@ module Rswag
 
       def definitions_or_component_schemas(swagger_doc, version)
         if version.start_with?('2')
-          swagger_doc.slice(:definitions)
+          swagger_doc.slice(:definitions, :responses)
         else # Openapi3
           if swagger_doc.key?(:definitions)
             ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: definitions is replaced in OpenAPI3! Rename to components/schemas (in swagger_helper.rb)')

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -122,6 +122,24 @@ module Rswag
               metadata[:response][:schema] = { '$ref' => '#/definitions/blog' }
             end
 
+            context 'with shared `responses` as a part of swagger schema' do
+              before do
+                swagger_doc[:responses] = {
+                  'NotFound' => {
+                    type: :object,
+                    properties: { message: { type: :string } },
+                    required: ['message']
+                  }
+                }
+                metadata[:response][:schema] = { '$ref' => '#/responses/NotFound' }
+              end
+
+              it 'uses the referenced schema to validate the response body' do
+                expect { call }.to raise_error(/did not contain a required property of 'message'/)
+              end
+              
+            end
+
             it 'uses the referenced schema to validate the response body' do
               expect { call }.to raise_error(/Expected response body/)
             end


### PR DESCRIPTION
## Problem
Can't describe endpoint response schema using global `responses` section as a `$ref`.

## Solution
When fetching `'definitions'` from swagger_doc we should also fetch `'responses'`.

### This concerns this parts of the Open API Specification:
> If multiple operations return the same response (status code and data), you can define it in the global responses section and reference that definition via $ref at the operation level.
* [Describing Responses](https://swagger.io/docs/specification/2-0/describing-responses/). Specifically look for "Reusing Responses" section.

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

This change is only relevant to swagger 2.0.

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
Consider the following
swagger_helper.rb
```ruby
RSpec.configure do |config|
  config.swagger_root = '.'
  
  config.swagger_docs = {
    'swagger.json' => {
      "swagger": "2.0",
      "responses": {
        "NotFound": {
          "description": "Object not found"
        }
      }
    }
  }
end
```
then the following should work
spec/requests/whatever_spec.rb
```ruby
require 'swagger_helper'

RSpec.describe 'Whatever API', type: :request do
  path '/whatever' do
    get 'Gets Whatever' do
      response 404, 'Whatever not found' do
        schema '$ref': '#/responses/NotFound'

        run_test!
      end
    end
  end
end
```
