### PR TITLE
Always add additional_rspec_opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fix ADDITIONAL_RSPEC_OPTS to always apply (https://github.com/rswag/rswag/pull/584)
+
 ### Documentation
 
 ## [2.8.0]

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -16,11 +16,13 @@ namespace :rswag do
         ''
       )
 
+      t.rspec_opts = [additional_rspec_opts]
+
       if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.swagger_dry_run
-        t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined'] << additional_rspec_opts
+        t.rspec_opts += ['--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined']
       else
         ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
-        t.rspec_opts = ['--format Rswag::Specs::SwaggerFormatter', '--order defined']
+        t.rspec_opts += ['--format Rswag::Specs::SwaggerFormatter', '--order defined']
       end
     end
   end


### PR DESCRIPTION
## Problem
ADDITIONAL_RSPEC_OPTS was only applied when `swagger_dry_run` was truthy, but they should always be applied. 

## Solution
always set the options, regardless of `swagger_dry_run` and `RSPEC_VERSION`

### This concerns this parts of the Open API Specification:
N/A

### The changes I made are compatible with:
- [X] OAS2
- [X] OAS3
- [X] OAS3.1

### Related Issues
N/A

### Checklist
- [ ] Added tests - Not sure how to test this
- [X] Changelog updated
- [X] Added documentation to README.md

### Steps to Test or Reproduce
Run `ADDITIONAL_RSPEC_OPTS='--tag rswag' SWAGGER_DRY_RUN=0 rake swaggerize` and notice that the `--tag rswag` doesn't appear.
