### PR TITLE
fix: mismatched types on compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix ADDITIONAL_RSPEC_OPTS to always apply (https://github.com/rswag/rswag/pull/584)
+- Fix apiKey can not be declared as `String` (https://github.com/rswag/rswag/pull/589)
 
 ### Documentation
 

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -43,7 +43,7 @@ module Rswag
         schemes = security_version(scheme_names, swagger_doc)
 
         schemes.map do |scheme|
-          param = (scheme[:type] == :apiKey) ? scheme.slice(:name, :in) : { name: 'Authorization', in: :header }
+          param = (scheme[:type]&.to_sym == :apiKey) ? scheme.slice(:name, :in) : { name: 'Authorization', in: :header }
           param.merge(type: :string, required: requirements.one?)
         end
       end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -451,7 +451,7 @@ module Rswag
 
         context 'apiKey' do
           before do
-            swagger_doc[:securityDefinitions] = { apiKey: { type: :apiKey, name: 'api_key', in: key_location } }
+            swagger_doc[:securityDefinitions] = { apiKey: { type: 'apiKey', name: 'api_key', in: key_location } }
             metadata[:operation][:security] = [apiKey: []]
             allow(example).to receive(:api_key).and_return('foobar')
           end
@@ -460,12 +460,22 @@ module Rswag
             let(:key_location) { :query }
 
             it 'adds name and example value to the query string' do
+              swagger_doc[:securityDefinitions][:apiKey][:type] = :apiKey
+              expect(request[:path]).to eq('/blogs?api_key=foobar')
+            end
+
+            it 'adds name and example value to the query string' do
               expect(request[:path]).to eq('/blogs?api_key=foobar')
             end
           end
 
           context 'in header' do
             let(:key_location) { :header }
+
+            it 'adds name and example value to the headers' do
+              swagger_doc[:securityDefinitions][:apiKey][:type] = :apiKey
+              expect(request[:headers]).to eq('api_key' => 'foobar')
+            end
 
             it 'adds name and example value to the headers' do
               expect(request[:headers]).to eq('api_key' => 'foobar')
@@ -481,6 +491,12 @@ module Rswag
               ]
               allow(example).to receive(:q1).and_return('foo')
               allow(example).to receive(:api_key).and_return('foobar')
+            end
+
+            it 'adds authorization parameter only once' do
+              swagger_doc[:securityDefinitions][:apiKey][:type] = :apiKey
+              expect(request[:headers]).to eq('api_key' => 'foobar')
+              expect(metadata[:operation][:parameters].size).to eq 2
             end
 
             it 'adds authorization parameter only once' do


### PR DESCRIPTION
## Problem
`apiKey` type security is only valid on declare as Symbol, and is invalid as String

## Solution
convert type as symbol before compare

### This concerns this parts of the Open API Specification:
* [LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce

```rb
# spec/swagger_helper.rb
RSpec.configure do |config|
  config.swagger_root = Rails.root.to_s + '/swagger'

  config.swagger_docs = {
    'v1/swagger.json' => {
      components: {
        securitySchemes: {
          api_key: {
            type: 'apiKey',  # <= see here, declare as String
            name: 'api_key',
            in: :query
          }
        }
      }
    }
  }
end
```

```rb
# example of documenting an endpoint that handles basic auth and api key based security
describe 'Auth examples API' do
  path '/auth-tests/basic-and-api-key' do
    post 'Authenticates with basic auth and api key' do
      tags 'Auth Tests'
      operationId 'testBasicAndApiKey'
      security [{ basic_auth: [], api_key: [] }]

      response '204', 'Valid credentials' do
        let(:api_key) { 'foobar' }
        run_test!
      end

      response '401', 'Invalid credentials' do
        let(:api_key) { 'bar-foo' }
        run_test!
      end
    end
  end
end
```