### PR TITLE
Fix RequestFactory gsub for base_path_from_servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Invalid URI error when specifying protocol within server configuration
 - Fix ADDITIONAL_RSPEC_OPTS to always apply (https://github.com/rswag/rswag/pull/584)
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Invalid URI error when specifying protocol within server configuration
+- Invalid URI error when specifying protocol within server configuration (https://github.com/rswag/rswag/pull/591)
 - Fix ADDITIONAL_RSPEC_OPTS to always apply (https://github.com/rswag/rswag/pull/584)
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -313,8 +313,11 @@ RSpec.configure do |config|
       },
       servers: [
         {
-          url: 'https://{defaultHost}',
+          url: '{protocol}://{defaultHost}',
           variables: {
+            protocol: {
+              default: :https
+            },
             defaultHost: {
                 default: 'www.example.com'
             }

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -106,7 +106,7 @@ module Rswag
         server = swagger_doc[:servers].first
         variables = {}
         server.fetch(:variables, {}).each_pair { |k,v| variables[k] = v[use_server] }
-        base_path = server[:url].gsub(/\{(.*?)\}/) { |name| variables[name.tr('{}','').to_sym] }
+        base_path = server[:url].gsub(/\{(.*?)\}/) { variables[$1.to_sym] }
         URI(base_path).path
       end
 

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -106,7 +106,7 @@ module Rswag
         server = swagger_doc[:servers].first
         variables = {}
         server.fetch(:variables, {}).each_pair { |k,v| variables[k] = v[use_server] }
-        base_path = server[:url].gsub(/\{(.*?)\}/) { |name| variables[name.to_sym] }
+        base_path = server[:url].gsub(/\{(.*?)\}/) { |name| variables[name.tr('{}','').to_sym] }
         URI(base_path).path
       end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -589,8 +589,11 @@ module Rswag
           context 'openapi 3.0' do
             before do
               swagger_doc[:servers] = [{
-                :url => "https://{defaultHost}",
+                :url => "{protocol}://{defaultHost}",
                 :variables => {
+                  :protocol => {
+                    :default => :https
+                  },
                   :defaultHost => {
                     :default => "www.example.com"
                   }

--- a/test-app/spec/swagger_helper.rb
+++ b/test-app/spec/swagger_helper.rb
@@ -24,8 +24,11 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: 'https://{defaultHost}',
+          url: '{protocol}://{defaultHost}',
           variables: {
+            protocol: {
+              default: :https
+            },
             defaultHost: {
               default: 'www.example.com'
             }


### PR DESCRIPTION
## Problem
Commit 2264b033e8ff7c88d04a800c9197f7dc8971ac47 introduced a change to this method where the gsub replacement of the server url switched from the global Regexp match variable of $1 to the block argument for gsub.

This change made it so that the argument to the variable name lookup include the braces used in the string for the url variable.

That lead to the hash not returing any matching keys and values and the generated URI string of '://' being passed to the URI() method which raise an error.

## Solution

The solution is to ~~use `tr` to replace matching `{` and `}` characters from the block argument passed to `gsub!`~~ use the global Regex `$1` match variable in `Rswag::Specs::RequestFactory#base_path_from_servers`

### This concerns this parts of the Open API Specification:
* [Server Object specification](https://spec.openapis.org/oas/v3.1.0#server-object) does not list `protocol`

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
None

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce

The configuration in the spec was updated to include a `protocol` value in the server variables with a `:default` key. Only this change is necessary to trigger an Invalid URI error.
