### PR TITLE
Strict schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Added option --spec_path to the generator command with requests as default value (https://github.com/rswag/rswag/pull/607)
 - Add support for `:getter` parameter option to explicitly define custom parameter getter method and avoid RSpec conflicts with `include` matcher and `status` method (https://github.com/rswag/rswag/pull/605)
-- Added support strict schema validation (https://github.com/rswag/rswag/pull/604)
+- Added support strict schema validation and allow to pass metadata to run_test! (https://github.com/rswag/rswag/pull/604)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added option --spec_path to the generator command with requests as default value (https://github.com/rswag/rswag/pull/607)
 - Add support for `:getter` parameter option to explicitly define custom parameter getter method and avoid RSpec conflicts with `include` matcher and `status` method (https://github.com/rswag/rswag/pull/605)
 - Added support strict schema validation (https://github.com/rswag/rswag/pull/604)
+
 ### Changed
 
 - Remove commented code (https://github.com/rswag/rswag/pull/576)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Added option --spec_path to the generator command with requests as default value. (https://github.com/rswag/rswag/pull/607)
+- Added option --spec_path to the generator command with requests as default value (https://github.com/rswag/rswag/pull/607)
 - Add support for `:getter` parameter option to explicitly define custom parameter getter method and avoid RSpec conflicts with `include` matcher and `status` method (https://github.com/rswag/rswag/pull/605)
-
+- Added support strict schema validation (https://github.com/rswag/rswag/pull/604)
 ### Changed
 
 - Remove commented code (https://github.com/rswag/rswag/pull/576)

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ describe 'Blogs API' do
       response '201', 'blog created' do
         let(:blog) { { title: 'foo', content: 'bar' } }
 
-        run_test!(strict: true)
+        run_test!(swagger_strict_schema_validation: true)
       end
     end
   end

--- a/README.md
+++ b/README.md
@@ -218,6 +218,70 @@ end
 
 Also note that the examples generated with __run_test!__ are tagged with the `:rswag` so they can easily be filtered. E.g. `rspec --tag rswag`
 
+### Strict schema validation
+
+By default, if response body contains undocumented properties tests will pass. To keep your responses clean and validate against a strict schema definition you can set the global config option:
+
+```ruby
+# spec/swagger_helper.rb
+RSpec.configure do |config|
+  config.swagger_strict_schema_validation = true
+end
+```
+
+or set the option per individual example:
+
+```ruby
+# using in run_test!
+describe 'Blogs API' do
+  path '/blogs' do
+    post 'Creates a blog' do
+      ...
+      response '201', 'blog created' do
+        let(:blog) { { title: 'foo', content: 'bar' } }
+
+        run_test!(strict: true)
+      end
+    end
+  end
+end
+
+# using in response block
+describe 'Blogs API' do
+  path '/blogs' do
+    post 'Creates a blog' do
+      ...
+
+      response '201', 'blog created', swagger_strict_schema_validation: true do
+        let(:blog) { { title: 'foo', content: 'bar' } }
+
+        run_test!
+      end
+    end
+  end
+end
+
+# using in an explicit example
+describe 'Blogs API' do
+  path '/blogs' do
+    post 'Creates a blog' do
+      ...
+      response '201', 'blog created' do
+        let(:blog) { { title: 'foo', content: 'bar' } }
+
+        before do |example|
+          submit_request(example.metadata)
+        end
+
+        it 'returns a valid 201 response', swagger_strict_schema_validation: true do |example|
+          assert_response_matches_metadata(example.metadata)
+        end
+      end
+    end
+  end
+end
+```
+
 ### Null Values ###
 
 This library is currently using JSON::Draft4 for validation of response models. Nullable properties can be supported with the non-standard property 'x-nullable' to a definition to allow null/nil values to pass. Or you can add the new standard ```nullable``` property to a definition.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ If you've used [Swagger](http://swagger.io/specification) before, then the synta
 
 Take special note of the __run_test!__ method that's called within each response block. This tells rswag to create and execute a corresponding example. It builds and submits a request based on parameter descriptions and corresponding values that have been provided using the rspec "let" syntax. For example, the "post" description in the example above specifies a "body" parameter called "blog". It also lists 2 different responses. For the success case (i.e. the 201 response), notice how "let" is used to set the blog parameter to a value that matches the provided schema. For the failure case (i.e. the 422 response), notice how it's set to a value that does not match the provided schema. When the test is executed, rswag also validates the actual response code and, where applicable, the response body against the provided [JSON Schema](http://json-schema.org/documentation.html).
 
+If you want to add metadata to the example, you can pass keyword arguments to the __run_test!__ method:
+
+```ruby
+# to run particular test case
+response '201', 'blog created' do
+  run_test! focus: true
+end
+
+# to write vcr cassette
+response '201', 'blog created' do
+  run_test! vcr: true
+end
+```
+
 If you want to do additional validation on the response, pass a block to the __run_test!__ method:
 
 ```ruby

--- a/rswag-specs/lib/rswag/specs.rb
+++ b/rswag-specs/lib/rswag/specs.rb
@@ -14,6 +14,7 @@ module Rswag
       c.add_setting :swagger_docs
       c.add_setting :swagger_dry_run
       c.add_setting :swagger_format
+      c.add_setting :swagger_strict_schema_validation
       c.extend ExampleGroupHelpers, type: :request
       c.include ExampleHelpers, type: :request
     end

--- a/rswag-specs/lib/rswag/specs/configuration.rb
+++ b/rswag-specs/lib/rswag/specs/configuration.rb
@@ -55,6 +55,10 @@ module Rswag
         doc = get_swagger_doc(name)
         doc[:openapi] || doc[:swagger]
       end
+
+      def swagger_strict_schema_validation
+        @swagger_strict_schema_validation ||= (@rspec_config.swagger_strict_schema_validation || false)
+      end
     end
 
     class ConfigurationError < StandardError; end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -115,6 +115,12 @@ module Rswag
         )
       end
 
+      #
+      # Perform request and assert response matches swagger definitions
+      #
+      # @param strict: nil [Boolean] whether to validate response against given schema strictly
+      # @param &block [Proc] you can make additional assertions within that block
+      # @return [void]
       def run_test!(&block)
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
@@ -123,7 +129,7 @@ module Rswag
           end
 
           it "returns a #{metadata[:response][:code]} response", rswag: true do
-            assert_response_matches_metadata(metadata)
+            assert_response_matches_metadata(metadata.merge(options))
             block.call(response) if block_given?
           end
         else
@@ -132,7 +138,7 @@ module Rswag
           end
 
           it "returns a #{metadata[:response][:code]} response", rswag: true do |example|
-            assert_response_matches_metadata(example.metadata, &block)
+            assert_response_matches_metadata(example.metadata.merge(options), &block)
             example.instance_exec(response, &block) if block_given?
           end
         end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -118,10 +118,10 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
-      # @param strict: nil [Boolean] whether to validate response against given schema strictly
+      # @param swagger_strict_schema_validation: nil [Boolean] whether to validate response against given schema strictly
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
-      def run_test!(&block)
+      def run_test!(**options, &block)
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
           before do

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -122,14 +122,16 @@ module Rswag
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
       def run_test!(**options, &block)
+        options[:rswag] = true unless options.key?(:rswag)
+
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
           before do
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response", rswag: true do
-            assert_response_matches_metadata(metadata.merge(options))
+          it "returns a #{metadata[:response][:code]} response", **options do
+            assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
         else
@@ -137,8 +139,8 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response", rswag: true do |example|
-            assert_response_matches_metadata(example.metadata.merge(options), &block)
+          it "returns a #{metadata[:response][:code]} response", **options do |example|
+            assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end
         end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -56,16 +56,16 @@ module Rswag
       end
 
 
-      def request_body_example(value:, summary: nil, name: nil) 
-        if metadata.key?(:operation) 
+      def request_body_example(value:, summary: nil, name: nil)
+        if metadata.key?(:operation)
           metadata[:operation][:request_examples] ||= []
-          example = { value: value } 
-          example[:summary] = summary if summary 
+          example = { value: value }
+          example[:summary] = summary if summary
           # We need the examples to have a unique name for a set of examples, so just make the name the length if one isn't provided.
           example[:name] = name || metadata[:operation][:request_examples].length()
           metadata[:operation][:request_examples] << example
-        end 
-      end 
+        end
+      end
 
       def response(code, description, metadata = {}, &block)
         metadata[:response] = { code: code, description: description }
@@ -118,7 +118,7 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
-      # @param swagger_strict_schema_validation: nil [Boolean] whether to validate response against given schema strictly
+      # @param options [Hash] options to pass to the `it` method
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
       def run_test!(**options, &block)

--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -62,12 +62,23 @@ module Rswag
           .merge('$schema' => 'http://tempuri.org/rswag/specs/extended_schema')
           .merge(schemas)
 
-        errors = JSON::Validator.fully_validate(validation_schema, body)
+        validation_options = validation_options_from(metadata)
+
+        errors = JSON::Validator.fully_validate(validation_schema, body, validation_options)
         return unless errors.any?
 
         raise UnexpectedResponse,
               "Expected response body to match schema: #{errors.join("\n")}\n" \
               "Response body: #{JSON.pretty_generate(JSON.parse(body))}"
+      end
+
+      def validation_options_from(metadata)
+        is_strict = !!metadata.fetch(
+          :swagger_strict_schema_validation,
+          @config.swagger_strict_schema_validation
+        )
+
+        { strict: is_strict }
       end
 
       def definitions_or_component_schemas(swagger_doc, version)

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -109,6 +109,36 @@ module Rswag
           it { expect { call }.to raise_error(/Expected response body/) }
         end
 
+        context "when response body has additional properties" do
+          before { response.body = '{"foo":"Some comment", "text":"bar"}' }
+
+          context "with strict schema validation enabled" do
+            let(:swagger_strict_schema_validation) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation disabled" do
+            let(:swagger_strict_schema_validation) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with strict schema validation disabled in config but enabled in metadata" do
+            let(:swagger_strict_schema_validation) { false }
+            let(:metadata) { super().merge(swagger_strict_schema_validation: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation enabled in config but disabled in metadata" do
+            let(:swagger_strict_schema_validation) { true }
+            let(:metadata) { super().merge(swagger_strict_schema_validation: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+        end
+
         context 'referenced schemas' do
           context 'swagger 2.0' do
             before do

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -10,28 +10,31 @@ module Rswag
       before do
         allow(config).to receive(:get_swagger_doc).and_return(swagger_doc)
         allow(config).to receive(:get_swagger_doc_version).and_return('2.0')
+        allow(config).to receive(:swagger_strict_schema_validation).and_return(swagger_strict_schema_validation)
       end
+
       let(:config) { double('config') }
       let(:swagger_doc) { {} }
       let(:example) { double('example') }
+      let(:swagger_strict_schema_validation) { false }
       let(:metadata) do
         {
           response: {
             code: 200,
-            headers: { 
+            headers: {
               'X-Rate-Limit-Limit' => { type: :integer },
-              'X-Cursor' => { 
-                schema: { 
+              'X-Cursor' => {
+                schema: {
                   type: :string
                 },
                 required: false
               },
-              'X-Per-Page' => { 
-                schema: { 
+              'X-Per-Page' => {
+                schema: {
                   type: :string,
                   nullable: true
                 }
-              } 
+              }
             },
             schema: {
               type: :object,
@@ -110,7 +113,7 @@ module Rswag
         end
 
         context "when response body has additional properties" do
-          before { response.body = '{"foo":"Some comment", "text":"bar"}' }
+          before { response.body = '{"foo":"Some comment", "number": 3, "text":"bar"}' }
 
           context "with strict schema validation enabled" do
             let(:swagger_strict_schema_validation) { true }

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -139,7 +139,12 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
         }
 
         let(:id) { blog.id }
+
         run_test!
+
+        context 'when swagger_strict_schema_validation is true' do
+          run_test!(swagger_strict_schema_validation: true)
+        end
       end
 
       response '404', 'blog not found' do


### PR DESCRIPTION
## Problem
I see some problems in ruby projects - it's data bloating. As projects grow they get complicated so it's hard to keep responses clean. It happed to projects I am working on and others(see the issue). So I decided to bring the changes back from initial issue.

## Solution
I want to add a new configuration option on top of the main called `additionalProperties` from [json-schema](https://github.com/voxpupuli/json-schema) to allow users to validate their schemas strictly.

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues

Closes https://github.com/rswag/rswag/issues/163

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
