### PR TITLE
parameter[:getter] option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Added option --spec_path to the generator command with requests as default value. (https://github.com/rswag/rswag/pull/607)
-- Add support for :getter parameter option to explicitly define custom param getter method and avoid rspec conflicts with `include` matcher and `status` method
+- Add support for `:getter` parameter option to explicitly define custom parameter getter method and avoid RSpec conflicts with `include` matcher and `status` method (https://github.com/rswag/rswag/pull/605)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+
 - Added option --spec_path to the generator command with requests as default value. (https://github.com/rswag/rswag/pull/607)
+- Add support for :getter parameter option to explicitly define custom param getter method and avoid rspec conflicts with `include` matcher and `status` method
+
 ### Changed
 
 - Remove commented code (https://github.com/rswag/rswag/pull/576)

--- a/README.md
+++ b/README.md
@@ -988,9 +988,9 @@ docker run -d -p 80:8080 swaggerapi/swagger-editor
 This will run the swagger editor in the docker daemon and can be accessed
 at ```http://localhost```. From here, you can use the UI to load the generated swagger.json to validate the output.
 
-### Custom :getter option for paramater
+### Custom :getter option for parameter
 
-To avoid conflicts with rspec `included` matcher and other possible intersections like `status` method:
+To avoid conflicts with Rspec [`include`](https://github.com/rspec/rspec-rails/blob/40261bb72875c00a6e4a0ca2ac697b660d4e8d9c/spec/support/generators.rb#L18) matcher and other possible intersections like `status` method:
 
 ```
 ...

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ end
 
 #### Nullable or Optional Response Headers ####
 
-You can include `nullable` or `required` to specify whether a response header must be present or may be null. When `nullable` is not included, the headers validation validates that the header response is non-null. When `required` is not included, the headers validation validates the the header response is passed. 
+You can include `nullable` or `required` to specify whether a response header must be present or may be null. When `nullable` is not included, the headers validation validates that the header response is non-null. When `required` is not included, the headers validation validates the the header response is passed.
 
 ```ruby
 # spec/integration/comments_spec.rb
@@ -987,3 +987,21 @@ docker run -d -p 80:8080 swaggerapi/swagger-editor
 ```
 This will run the swagger editor in the docker daemon and can be accessed
 at ```http://localhost```. From here, you can use the UI to load the generated swagger.json to validate the output.
+
+### Custom :getter option for paramater
+
+To avoid conflicts with rspec `included` matcher and other possible intersections like `status` method:
+
+```
+...
+parameter name: :status,
+          getter: :filter_status,
+          in: :query,
+          schema: {
+            type: :string,
+            enum: %w[one two three],
+          }, required: false
+
+let(:status) { nil } # will not be used in query string
+let(:filter_status) { 'one' } # `&status=one` will be provided in final query
+```

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -58,6 +58,9 @@ module Rswag
                 if is_hash && value[:parameters]
                   schema_param = value[:parameters]&.find { |p| (p[:in] == :body || p[:in] == :formData) && p[:schema] }
                   mime_list = value[:consumes] || doc[:consumes]
+
+                  value[:parameters].each {|p| p.delete(:getter) } # remove service field
+
                   if value && schema_param && mime_list
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     value[:requestBody][:required] = true if schema_param[:required]

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -59,8 +59,6 @@ module Rswag
                   schema_param = value[:parameters]&.find { |p| (p[:in] == :body || p[:in] == :formData) && p[:schema] }
                   mime_list = value[:consumes] || doc[:consumes]
 
-                  value[:parameters].each {|p| p.delete(:getter) } # remove service field
-
                   if value && schema_param && mime_list
                     value[:requestBody] = { content: {} } unless value.dig(:requestBody, :content)
                     value[:requestBody][:required] = true if schema_param[:required]
@@ -210,10 +208,12 @@ module Rswag
       end
 
       def remove_invalid_operation_keys!(value)
-        is_hash = value.is_a?(Hash)
-        value.delete(:consumes) if is_hash && value[:consumes]
-        value.delete(:produces) if is_hash && value[:produces]
-        value.delete(:request_examples) if is_hash && value[:request_examples]
+        return unless value.is_a?(Hash)
+
+        value.delete(:consumes) if value[:consumes]
+        value.delete(:produces) if value[:produces]
+        value.delete(:request_examples) if value[:request_examples]
+        value[:parameters].each { |p| p.delete(:getter) } if value[:parameters]
       end
     end
   end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -98,7 +98,7 @@ module Rswag
               allow(example).to receive(:q3_status).and_return(123)
             end
 
-            it 'builds the query string using getter ethod' do
+            it 'builds the query string using getter method' do
               expect(request[:path]).to eq('/blogs?q1=foo&q2=bar&status=123')
             end
           end
@@ -108,45 +108,45 @@ module Rswag
           before do
             metadata[:operation][:parameters] = [
               { name: 'things', in: :query, type: :array, collectionFormat: collection_format },
-              { name: 'nums', in: :query, type: :array, collectionFormat: collection_format, getter: :nums_param },
+              { name: 'numbers', in: :query, type: :array, collectionFormat: collection_format, getter: :magic_numbers },
             ]
             allow(example).to receive(:things).and_return(['foo', 'bar'])
-            allow(example).to receive(:nums).and_return(nil)
-            allow(example).to receive(:nums_param).and_return([0, 1])
+            allow(example).to receive(:magic_numbers).and_return([0, 1])
+            expect(example).not_to receive(:numbers)
           end
 
           context 'collectionFormat = csv' do
             let(:collection_format) { :csv }
             it 'formats as comma separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo,bar&nums=0,1')
+              expect(request[:path]).to eq('/blogs?things=foo,bar&numbers=0,1')
             end
           end
 
           context 'collectionFormat = ssv' do
             let(:collection_format) { :ssv }
             it 'formats as space separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo bar&nums=0 1')
+              expect(request[:path]).to eq('/blogs?things=foo bar&numbers=0 1')
             end
           end
 
           context 'collectionFormat = tsv' do
             let(:collection_format) { :tsv }
             it 'formats as tab separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo\tbar&nums=0\t1')
+              expect(request[:path]).to eq('/blogs?things=foo\tbar&numbers=0\t1')
             end
           end
 
           context 'collectionFormat = pipes' do
             let(:collection_format) { :pipes }
             it 'formats as pipe separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo|bar&nums=0|1')
+              expect(request[:path]).to eq('/blogs?things=foo|bar&numbers=0|1')
             end
           end
 
           context 'collectionFormat = multi' do
             let(:collection_format) { :multi }
             it 'formats as multiple parameter instances' do
-              expect(request[:path]).to eq('/blogs?things=foo&things=bar&nums=0&nums=1')
+              expect(request[:path]).to eq('/blogs?things=foo&things=bar&numbers=0&numbers=1')
             end
           end
         end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -31,15 +31,15 @@ module Rswag
         end
 
         context "'path' parameters" do
-          context 'when `name` parameter key is required, but not defined within example group' do
-            before do
-              metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
-              metadata[:operation][:parameters] = [
-                { name: 'blog_id', in: :path, type: :number },
-                { name: 'id', in: :path, type: :number }
-              ]
-            end
+          before do
+            metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
+            metadata[:operation][:parameters] = [
+              { name: 'blog_id', in: :path, type: :number },
+              { name: 'id', in: :path, type: :number }
+            ]
+          end
 
+          context 'when `name` parameter key is required, but not defined within example group' do
             it "explicitly warns user about missing parameter, instead of giving generic error" do
               expect { request[:path] }.not_to raise_error(/undefined method/)
               expect { request[:path] }.not_to raise_error(/is not available from within an example/)
@@ -49,17 +49,27 @@ module Rswag
 
           context 'when `name` is defined' do
             before do
-              metadata[:path_item][:template] = '/blogs/{blog_id}/comments/{id}'
-              metadata[:operation][:parameters] = [
-                { name: 'blog_id', in: :path, type: :number },
-                { name: 'id', in: :path, type: :number }
-              ]
               allow(example).to receive(:blog_id).and_return(1)
               allow(example).to receive(:id).and_return(2)
             end
 
             it 'builds the path from example values' do
               expect(request[:path]).to eq('/blogs/1/comments/2')
+            end
+
+            context 'when `getter is defined`' do
+              before do
+                metadata[:operation][:parameters] = [
+                  { name: 'blog_id', in: :path, type: :number },
+                  { name: 'id', in: :path, type: :number, getter: :param_id }
+                ]
+
+                allow(example).to receive(:param_id).and_return(123)
+              end
+
+              it 'builds the path using getter method' do
+                expect(request[:path]).to eq('/blogs/1/comments/123')
+              end
             end
           end
         end
@@ -77,48 +87,66 @@ module Rswag
           it 'builds the query string from example values' do
             expect(request[:path]).to eq('/blogs?q1=foo&q2=bar')
           end
+
+          context 'when `getter is defined`' do
+            before do
+              metadata[:operation][:parameters] << {
+                name: 'status', in: :query, type: :string, getter: :q3_status
+              }
+
+              allow(example).to receive(:status).and_return(nil)
+              allow(example).to receive(:q3_status).and_return(123)
+            end
+
+            it 'builds the query string using getter ethod' do
+              expect(request[:path]).to eq('/blogs?q1=foo&q2=bar&status=123')
+            end
+          end
         end
 
         context "'query' parameters of type 'array'" do
           before do
             metadata[:operation][:parameters] = [
-              { name: 'things', in: :query, type: :array, collectionFormat: collection_format }
+              { name: 'things', in: :query, type: :array, collectionFormat: collection_format },
+              { name: 'nums', in: :query, type: :array, collectionFormat: collection_format, getter: :nums_param },
             ]
             allow(example).to receive(:things).and_return(['foo', 'bar'])
+            allow(example).to receive(:nums).and_return(nil)
+            allow(example).to receive(:nums_param).and_return([0, 1])
           end
 
           context 'collectionFormat = csv' do
             let(:collection_format) { :csv }
             it 'formats as comma separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo,bar')
+              expect(request[:path]).to eq('/blogs?things=foo,bar&nums=0,1')
             end
           end
 
           context 'collectionFormat = ssv' do
             let(:collection_format) { :ssv }
             it 'formats as space separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo bar')
+              expect(request[:path]).to eq('/blogs?things=foo bar&nums=0 1')
             end
           end
 
           context 'collectionFormat = tsv' do
             let(:collection_format) { :tsv }
             it 'formats as tab separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo\tbar')
+              expect(request[:path]).to eq('/blogs?things=foo\tbar&nums=0\t1')
             end
           end
 
           context 'collectionFormat = pipes' do
             let(:collection_format) { :pipes }
             it 'formats as pipe separated values' do
-              expect(request[:path]).to eq('/blogs?things=foo|bar')
+              expect(request[:path]).to eq('/blogs?things=foo|bar&nums=0|1')
             end
           end
 
           context 'collectionFormat = multi' do
             let(:collection_format) { :multi }
             it 'formats as multiple parameter instances' do
-              expect(request[:path]).to eq('/blogs?things=foo&things=bar')
+              expect(request[:path]).to eq('/blogs?things=foo&things=bar&nums=0&nums=1')
             end
           end
         end
@@ -271,12 +299,16 @@ module Rswag
 
         context "'header' parameters" do
           before do
-            metadata[:operation][:parameters] = [{ name: 'Api-Key', in: :header, type: :string }]
+            metadata[:operation][:parameters] = [
+              { name: 'Api-Key', in: :header, type: :string },
+              { name: 'Token', getter: :token_param, in: :header, type: :string }
+            ]
             allow(example).to receive(:'Api-Key').and_return('foobar')
+            allow(example).to receive(:'token_param').and_return('my_token')
           end
 
           it 'adds names and example values to headers' do
-            expect(request[:headers]).to eq({ 'Api-Key' => 'foobar' })
+            expect(request[:headers]).to eq({ 'Api-Key' => 'foobar', 'Token' => 'my_token' })
           end
         end
 

--- a/test-app/app/controllers/blogs_controller.rb
+++ b/test-app/app/controllers/blogs_controller.rb
@@ -10,7 +10,6 @@ class BlogsController < ApplicationController
 
   # POST /blogs/flexible
   def flexible_create
-
     # contrived example to play around with new anyOf and oneOf
     # request body definition for 3.0
     blog_params = params.require(:blog).permit(:title, :content, :headline, :text)
@@ -21,7 +20,6 @@ class BlogsController < ApplicationController
 
   # POST /blogs/alternate
   def alternate_create
-
     # contrived example to show different :examples in the requestBody section
     @blog = Blog.create(params.require(:blog).permit(:title, :content))
     respond_with @blog
@@ -38,6 +36,8 @@ class BlogsController < ApplicationController
   # GET /blogs
   def index
     @blogs = Blog.all
+    @blogs = @blogs.where(status: params[:status]) if params[:status].present?
+
     respond_with @blogs
   end
 

--- a/test-app/db/migrate/20160218212104_create_blogs.rb
+++ b/test-app/db/migrate/20160218212104_create_blogs.rb
@@ -10,6 +10,7 @@ class CreateBlogs < migration_class
       t.string :title
       t.text :content
       t.string :thumbnail
+      t.string :status
 
       t.timestamps
     end

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define(version: 2016_02_18_212104) do
     t.string "title"
     t.text "content"
     t.string "thumbnail"
+    t.string "status"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       produces 'application/json'
       parameter name: :blog, in: :body, schema: { '$ref' => '#/definitions/blog' }
 
-      let(:blog) { { title: 'foo', content: 'bar' } }
+      let(:blog) { { title: 'foo', content: 'bar', status: 'published' } }
 
       response '201', 'blog created' do
         # schema '$ref' => '#/definitions/blog'
@@ -39,11 +39,31 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       operationId 'searchBlogs'
       produces 'application/json'
       parameter name: :keywords, in: :query, type: 'string'
+      parameter name: :status, in: :query, type: 'string', getter: :blog_status
+
+      before do
+        Blog.create(title: 'foo', content: 'hello world', status: 'published')
+      end
 
       let(:keywords) { 'foo bar' }
+      let(:blog_status) { 'published' }
 
       response '200', 'success' do
         schema type: 'array', items: { '$ref' => '#/definitions/blog' }
+
+        run_test! do
+          expect(JSON.parse(response.body).size).to eq(1)
+        end
+      end
+
+      response '200', 'no content' do
+        schema type: 'array', items: { '$ref' => '#/definitions/blog' }
+
+        let(:blog_status) { 'invalid' }
+
+        run_test! do
+          expect(JSON.parse(response.body).size).to eq(0)
+        end
       end
 
       response '406', 'unsupported accept header' do

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -120,9 +120,29 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
+          "200": {
+            "description": "no content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/blog"
+                  }
+                }
+              }
+            }
+          },
           "406": {
             "description": "unsupported accept header"
           }


### PR DESCRIPTION
## Problem
Adopted pull request https://github.com/rswag/rswag/pull/436
Fix known issue: conflict with rspec default matchers include https://github.com/rswag/rswag/issues/188 (and also with status method)

## Solution
Add support for :getter parameter option to explicitly define custom param getter method and avoid rspec conflicts with include matcher and status method

### This concerns this parts of the OpenAPI Specification:
-

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [ ] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/188 

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
-
