### PR TITLE
feat: make spec folder configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-
+- Added option --spec_path to the generator command with requests as default value.
 ### Changed
 
 - Remove commented code (https://github.com/rswag/rswag/pull/576)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-- Added option --spec_path to the generator command with requests as default value.
+- Added option --spec_path to the generator command with requests as default value. (https://github.com/rswag/rswag/pull/607)
 ### Changed
 
 - Remove commented code (https://github.com/rswag/rswag/pull/576)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ There is also a generator which can help get you started `rails generate rspec:s
       end
     end
     ```
-
+By default, the above command will create spec under _spec/requests_ folder. You can pass an option to change this default path as in `rails generate rspec:swagger API::BlogsController --spec_path integration`.
+This will create the spec file _spec/integration/blogs_spec.rb_
 
 4. Generate the Swagger JSON file(s)
 

--- a/rswag-specs/lib/generators/rspec/swagger_generator.rb
+++ b/rswag-specs/lib/generators/rspec/swagger_generator.rb
@@ -6,13 +6,14 @@ require 'rails/generators'
 module Rspec
   class SwaggerGenerator < ::Rails::Generators::NamedBase
     source_root File.expand_path('templates', __dir__)
+    class_option :spec_path, type: :string, default: 'requests'
 
     def setup
       @routes = Rswag::RouteParser.new(controller_path).routes
     end
 
     def create_spec_file
-      template 'spec.rb', File.join('spec', 'requests', "#{controller_path}_spec.rb")
+      template 'spec.rb', File.join('spec', options['spec_path'], "#{controller_path}_spec.rb")
     end
 
     private

--- a/rswag-specs/spec/generators/rspec/swagger_generator_spec.rb
+++ b/rswag-specs/spec/generators/rspec/swagger_generator_spec.rb
@@ -28,6 +28,16 @@ module Rspec
       end
     end
 
+    it 'generates spec file for a controller in a defined directory' do
+      allow_any_instance_of(Rswag::RouteParser).to receive(:routes).and_return(fake_routes)
+      run_generator %w(Posts::CommentsController --spec_path=integration)
+
+      assert_file('spec/integration/posts/comments_spec.rb') do |content|
+        assert_match(/parameter name: 'post_id', in: :path, type: :string/, content)
+        assert_match(/patch\('update_comments comment'\)/, content)
+      end
+    end
+
     private
 
     def fake_routes


### PR DESCRIPTION
## Problem
The rspec generator only creates files under _spec/requests_ folder. I believe this option can be configurable/.

## Solution
Add option `--spec_path` to the generator command with `requests` as default value.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
Just run the generator command with `--spec_path` option.
