### PR TITLE
fix: add missing link to Content Security Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Invalid URI error when specifying protocol within server configuration (https://github.com/rswag/rswag/pull/591)
 - Fix ADDITIONAL_RSPEC_OPTS to always apply (https://github.com/rswag/rswag/pull/584)
+- Add missing link to Content Security Policy (https://github.com/rswag/rswag/pull/619)
 
 ### Documentation
 

--- a/rswag-ui/lib/rswag/ui/middleware.rb
+++ b/rswag-ui/lib/rswag/ui/middleware.rb
@@ -41,9 +41,9 @@ module Rswag
       end
 
       def csp
-        <<~POLICY.gsub "\n", ' '
+        <<~POLICY.tr "\n", ' '
           default-src 'self';
-          img-src 'self' data:;
+          img-src 'self' data: https://validator.swagger.io;
           font-src 'self' https://fonts.gstatic.com;
           style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
           script-src 'self' 'unsafe-inline';


### PR DESCRIPTION
Validation indicator has problems loading (see https://github.com/rswag/rswag/issues/174#issuecomment-1315774714)

## Problem
Link to [validator.swagger.io](https://validator.swagger.io/validator?url=https) is missing in Content Security Policy for UI middleware (merged in https://github.com/rswag/rswag/pull/263)

## Solution
Add link into CSP.

### This concerns this parts of the OpenAPI Specification:
--

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
- https://github.com/rswag/rswag/issues/174
- https://github.com/rswag/rswag/pull/263

### Checklist
- [ ] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce
-
