### PR TITLE
output warning if schema defined without produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added option --spec_path to the generator command with requests as default value (https://github.com/rswag/rswag/pull/607)
 - Add support for `:getter` parameter option to explicitly define custom parameter getter method and avoid RSpec conflicts with `include` matcher and `status` method (https://github.com/rswag/rswag/pull/605)
 - Added support strict schema validation and allow to pass metadata to run_test! (https://github.com/rswag/rswag/pull/604)
+- Added the `WARNING` output in case `produces` is missing for any of responses. (https://github.com/rswag/rswag/pull/620)
 
 ### Changed
 

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -138,6 +138,18 @@ module Rswag
         # Accept header
         mime_list = Array(metadata[:operation][:produces] || swagger_doc[:produces])
         target_node = metadata[:response]
+        if !target_node[:schema].nil? && mime_list.empty?
+          puts <<~TXT
+            WARNING: Ommiting schema for `#{metadata[:location]}`. No mime type specified for response schema.
+            Use `produces 'application/json'` in `response` section or define in `spec/swagger_helper.rb`:
+            ```
+            config.swagger_docs = {
+              "v1/swagger.yaml" => {
+                produces: "application/json",
+                ...
+            ```
+          TXT
+        end
         upgrade_content!(mime_list, target_node)
         metadata[:response].delete(:schema)
       end

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -14,7 +14,9 @@
         "operationId": "testBasicAuth",
         "security": [
           {
-            "basic_auth": []
+            "basic_auth": [
+
+            ]
           }
         ],
         "responses": {
@@ -36,7 +38,9 @@
         "operationId": "testApiKey",
         "security": [
           {
-            "api_key": []
+            "api_key": [
+
+            ]
           }
         ],
         "responses": {
@@ -58,8 +62,12 @@
         "operationId": "testBasicAndApiKey",
         "security": [
           {
-            "basic_auth": [],
-            "api_key": []
+            "basic_auth": [
+
+            ],
+            "api_key": [
+
+            ]
           }
         ],
         "responses": {
@@ -80,7 +88,9 @@
         ],
         "description": "Creates a new blog from provided data",
         "operationId": "createBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "201": {
             "description": "blog created"
@@ -157,7 +167,9 @@
         ],
         "description": "Creates a flexible blog from provided data",
         "operationId": "createFlexibleBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "201": {
             "description": "flexible blog created",
@@ -287,7 +299,9 @@
         ],
         "description": "Upload a thumbnail for specific blog by id",
         "operationId": "uploadThumbnailBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "200": {
             "description": "blog updated"
@@ -309,8 +323,11 @@
   },
   "servers": [
     {
-      "url": "https://{defaultHost}",
+      "url": "{protocol}://{defaultHost}",
       "variables": {
+        "protocol": {
+          "default": "https"
+        },
         "defaultHost": {
           "default": "www.example.com"
         }

--- a/test-app/swagger/v3/openapi.json
+++ b/test-app/swagger/v3/openapi.json
@@ -48,6 +48,19 @@
         }
       }
     },
+    "/no_produces_stubs_with_schema": {
+      "get": {
+        "summary": "a summary",
+        "tags": [
+          "Media Types"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/stubs/{a_param}": {
       "get": {
         "summary": "a summary",


### PR DESCRIPTION
## Problem
During the rebase I missed `produces` for some of the paths and responses schema dissaperaed. It took me a while to find out what was the problem
## Solution
The solution was to properly setup `produces` mime-type for swagger doc but it would save me time if there was a warning that says I missing something. So the PR is adding this warning.

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
