### PR TITLE
Fix encoding of query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix encoding of query params (https://github.com/rswag/rswag/pull/621)
+
 ### Added
 
 - Allow passing metadata to HTTP verb methods (https://github.com/rswag/rswag/pull/628)

--- a/README.md
+++ b/README.md
@@ -240,6 +240,22 @@ end
 
 Also note that the examples generated with __run_test!__ are tagged with the `:rswag` so they can easily be filtered. E.g. `rspec --tag rswag`
 
+### date-time in query parameters
+
+Input that is being sent in querys of rspec tests is html safe. That includes date-time strings. It was solved in this [`pr`](https://github.com/rswag/rswag/pull/621). Here is an example test:
+
+```ruby
+parameter name: :date_time, in: :query, type: :string
+
+response '200', 'blog found' do
+  let(:date_time) { DateTime.new(2001, 2, 3, 4, 5, 6, '-7').to_s }
+
+  run_test! do
+    expect(request[:path]).to eq('/blogs?date_time=2001-02-03T04%3A05%3A06-07%3A00')
+  end
+end
+```
+
 ### Strict schema validation
 
 By default, if response body contains undocumented properties tests will pass. To keep your responses clean and validate against a strict schema definition you can set the global config option:

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Also note that the examples generated with __run_test!__ are tagged with the `:r
 
 ### date-time in query parameters
 
-Input that is being sent in querys of rspec tests is html safe. That includes date-time strings. It was solved in this [`pr`](https://github.com/rswag/rswag/pull/621). Here is an example test:
+Input sent in queries of Rspec tests is HTML safe, including date-time strings.
 
 ```ruby
 parameter name: :date_time, in: :query, type: :string

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -178,7 +178,7 @@ module Rswag
         end
 
         type = param[:type] || param.dig(:schema, :type)
-        return "#{name}=#{value}" unless type&.to_sym == :array
+        return "#{CGI.escape(name.to_s)}=#{CGI.escape(value.to_s)}" unless type&.to_sym == :array
 
         case param[:collectionFormat]
         when :ssv

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -142,6 +142,7 @@ module Rswag
 
       def build_query_string_part(param, value, swagger_doc)
         name = param[:name]
+        escaped_name = CGI.escape(name.to_s)
 
         # OAS 3: https://swagger.io/docs/specification/serialization/
         if swagger_doc && doc_version(swagger_doc).start_with?('3') && param[:schema]
@@ -157,20 +158,20 @@ module Rswag
               if explode
                 return value.to_query
               else
-                return "#{CGI.escape(name.to_s)}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(',')
+                return "#{escaped_name}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(',')
               end
             end
           when :array
             case explode
             when true
-              return value.to_a.flatten.map{|v| "#{CGI.escape(name.to_s)}=#{CGI.escape(v.to_s)}"}.join('&')
+              return value.to_a.flatten.map{|v| "#{escaped_name}=#{CGI.escape(v.to_s)}"}.join('&')
             else
               separator = case style
                           when :form then ','
                           when :spaceDelimited then '%20'
                           when :pipeDelimited then '|'
                           end
-              return "#{CGI.escape(name.to_s)}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(separator)
+              return "#{escaped_name}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(separator)
             end
           else
             return "#{name}=#{value}"
@@ -178,7 +179,7 @@ module Rswag
         end
 
         type = param[:type] || param.dig(:schema, :type)
-        return "#{CGI.escape(name.to_s)}=#{CGI.escape(value.to_s)}" unless type&.to_sym == :array
+        return "#{escaped_name}=#{CGI.escape(value.to_s)}" unless type&.to_sym == :array
 
         case param[:collectionFormat]
         when :ssv

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -151,6 +151,28 @@ module Rswag
           end
         end
 
+        context "'query' parameter of format 'datetime'" do
+          let(:date_time) { DateTime.now.to_s }
+
+          before do
+            metadata[:operation][:parameters] = [
+              { name: 'date_time', in: :query, type: :string, format: :datetime, }
+            ]
+            allow(example).to receive(:date_time).and_return(DateTime.now.to_s)
+          end
+
+          it 'formats the datetime properly' do
+            expect(request[:path]).to eq("/blogs?date_time=#{CGI.escape(DateTime.now.to_s)}")
+          end
+
+          context "iso8601 format" do
+            let(:date_time) { DateTime.now.iso8601 }
+            it 'is also formated properly' do
+              expect(request[:path]).to eq("/blogs?date_time=#{CGI.escape(DateTime.now.iso8601)}")
+            end
+          end
+        end
+
         context "'query' parameters of type 'object'" do
           let(:things) { {'foo': 'bar'} }
           let(:swagger_doc) { { swagger: '3.0' } }

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -152,23 +152,23 @@ module Rswag
         end
 
         context "'query' parameter of format 'datetime'" do
-          let(:date_time) { DateTime.now.to_s }
+          let(:date_time) { DateTime.new(2001, 2, 3, 4, 5, 6, '-7').to_s  }
 
           before do
             metadata[:operation][:parameters] = [
               { name: 'date_time', in: :query, type: :string, format: :datetime, }
             ]
-            allow(example).to receive(:date_time).and_return(DateTime.now.to_s)
+            allow(example).to receive(:date_time).and_return(date_time)
           end
 
           it 'formats the datetime properly' do
-            expect(request[:path]).to eq("/blogs?date_time=#{CGI.escape(DateTime.now.to_s)}")
+            expect(request[:path]).to eq('/blogs?date_time=2001-02-03T04%3A05%3A06-07%3A00')
           end
 
           context "iso8601 format" do
-            let(:date_time) { DateTime.now.iso8601 }
-            it 'is also formated properly' do
-              expect(request[:path]).to eq("/blogs?date_time=#{CGI.escape(DateTime.now.iso8601)}")
+            let(:date_time) { DateTime.new(2001, 2, 3, 4, 5, 6, '-7').iso8601 }
+            it 'is also formatted properly' do
+              expect(request[:path]).to eq('/blogs?date_time=2001-02-03T04%3A05%3A06-07%3A00')
             end
           end
         end


### PR DESCRIPTION
## Problem
In query parameters, date-time formatted strings would not be encoded properly. This PR aims to fix this issue, and could potentially fix more issues than that. Strings should be escaped and formatted properly when being sent as query parameters.

## Solution
Add CGI.escape to method build_query_string_part

### This concerns this parts of the OpenAPI Specification:
--

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [ ] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/606

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
Add a parameter in query, that is a string type and is of datetime format.
Before this PR, the '+' symbol in the parameters would be turned into a white space after encoding.
