### PR TITLE
Add custom spec description option to `run_test!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added option --spec_path to the generator command with requests as default value (https://github.com/rswag/rswag/pull/607)
 - Add support for `:getter` parameter option to explicitly define custom parameter getter method and avoid RSpec conflicts with `include` matcher and `status` method (https://github.com/rswag/rswag/pull/605)
 - Added support strict schema validation and allow to pass metadata to run_test! (https://github.com/rswag/rswag/pull/604)
+- Add support for passing a custom specification description to `run_test!` (https://github.com/rswag/rswag/pull/622)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ response '201', 'blog created' do
 end
 ```
 
+If you want to customize the description of the generated specification, the `description` option can be passed to **run_test!**
+
+```ruby
+response '201', 'blog created' do
+  run_test! description: "custom spec description"
+end
+```
+
 If you want to do additional validation on the response, pass a block to the __run_test!__ method:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ response '201', 'blog created' do
 end
 ```
 
-If you want to customize the description of the generated specification, the `description` option can be passed to **run_test!**
+If you want to customize the description of the generated specification, a description can be passed to **run_test!**
 
 ```ruby
 response '201', 'blog created' do
-  run_test! description: "custom spec description"
+  run_test! "custom spec description"
 end
 ```
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -55,7 +55,6 @@ module Rswag
         end
       end
 
-
       def request_body_example(value:, summary: nil, name: nil)
         if metadata.key?(:operation)
           metadata[:operation][:request_examples] ||= []
@@ -123,6 +122,7 @@ module Rswag
       # @return [void]
       def run_test!(**options, &block)
         options[:rswag] = true unless options.key?(:rswag)
+        description = options.delete(:description) || "returns a #{metadata[:response][:code]} response"
 
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
@@ -130,7 +130,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response", **options do
+          it description, **options do
             assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
@@ -139,7 +139,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it "returns a #{metadata[:response][:code]} response", **options do |example|
+          it description, **options do |example|
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -117,13 +117,19 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
-      # @param description [String] description of the test
+      # @param args [Array] arguments to pass to the `it` method
       # @param options [Hash] options to pass to the `it` method
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
-      def run_test!(description = nil, **options, &block)
+      def run_test!(*args, **options, &block)
+        # rswag metadata value defaults to true
         options[:rswag] = true unless options.key?(:rswag)
+
+        # The first argument passed to `it` is the description. If it's not provided,
+        # we'll generate a default description based on the HTTP code of the response
+        description, *rest = *args
         description ||= "returns a #{metadata[:response][:code]} response"
+        args = [description, *rest]
 
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
@@ -131,7 +137,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it description, **options do
+          it *args, **options do
             assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
@@ -140,7 +146,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it description, **options do |example|
+          it *args, **options do |example|
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -117,12 +117,13 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
+      # @param description [String] description of the test
       # @param options [Hash] options to pass to the `it` method
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
-      def run_test!(**options, &block)
+      def run_test!(description = nil, **options, &block)
         options[:rswag] = true unless options.key?(:rswag)
-        description = options.delete(:description) || "returns a #{metadata[:response][:code]} response"
+        description ||= "returns a #{metadata[:response][:code]} response"
 
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -117,19 +117,16 @@ module Rswag
       #
       # Perform request and assert response matches swagger definitions
       #
+      # @param description [String] description of the test
       # @param args [Array] arguments to pass to the `it` method
       # @param options [Hash] options to pass to the `it` method
       # @param &block [Proc] you can make additional assertions within that block
       # @return [void]
-      def run_test!(*args, **options, &block)
+      def run_test!(description = nil, *args, **options, &block)
         # rswag metadata value defaults to true
         options[:rswag] = true unless options.key?(:rswag)
 
-        # The first argument passed to `it` is the description. If it's not provided,
-        # we'll generate a default description based on the HTTP code of the response
-        description, *rest = *args
         description ||= "returns a #{metadata[:response][:code]} response"
-        args = [description, *rest]
 
         if RSPEC_VERSION < 3
           ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
@@ -137,7 +134,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it *args, **options do
+          it description, *args, **options do
             assert_response_matches_metadata(metadata)
             block.call(response) if block_given?
           end
@@ -146,7 +143,7 @@ module Rswag
             submit_request(example.metadata)
           end
 
-          it *args, **options do |example|
+          it description, *args, **options do |example|
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -223,6 +223,37 @@ module Rswag
           )
         end
       end
+
+      describe "#run_test!" do
+        let(:rspec_version) { 3 }
+        let(:api_metadata) {
+          {
+            response: {
+              code: "200"
+            }
+          }
+        }
+
+        before do
+          stub_const("RSPEC_VERSION", rspec_version)
+          allow(subject).to receive(:before)
+          allow(subject).to receive(:description)
+        end
+
+        it "executes a specification" do
+          expected_spec_description = "returns a 200 response"
+          expect(subject).to receive(:it).with(expected_spec_description, rswag: true)
+          subject.run_test!
+        end
+
+        context "when options[:description] is passed" do
+          it "executes a specification described with passed description" do
+            expected_spec_description = "returns a 200 response - with a custom description"
+            expect(subject).to receive(:it).with(expected_spec_description, rswag: true)
+            subject.run_test!(description: expected_spec_description)
+          end
+        end
+      end
     end
   end
 end

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -237,7 +237,6 @@ module Rswag
         before do
           stub_const("RSPEC_VERSION", rspec_version)
           allow(subject).to receive(:before)
-          allow(subject).to receive(:description)
         end
 
         it "executes a specification" do
@@ -250,7 +249,7 @@ module Rswag
           it "executes a specification described with passed description" do
             expected_spec_description = "returns a 200 response - with a custom description"
             expect(subject).to receive(:it).with(expected_spec_description, rswag: true)
-            subject.run_test!(description: expected_spec_description)
+            subject.run_test!(expected_spec_description)
           end
         end
       end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -23,11 +23,15 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
         run_test!
       end
 
-      response '422', 'invalid request' do
-        schema '$ref' => '#/definitions/errors_object'
+      response "422", "invalid request" do
+        schema "$ref" => "#/definitions/errors_object"
 
-        let(:blog) { { title: 'foo' } }
-        run_test! do |response|
+        let(:blog) { {title: "foo"} }
+
+        run_test!
+
+        # Example to show custom specification description
+        run_test!("returns a 422 response - with error for missing content") do |response|
           expect(response.body).to include("can't be blank")
         end
       end


### PR DESCRIPTION
## Problem
Specifications generated by `run_test!` are essentially a hard coded string of "returns a RESPONSE_CODE response". If you need to customize this you have to break down into the individual parts that `run_test!` constructs for us.

```ruby
it "custom specification description here" do |example|
  submit_request(example.metadata)
  assert_response_matches_metadata(example.metadata)
end
```

## Solution
To facilitate configuration without the need to break out of the nicety that `run_test!` provides, we can now pass a `description` as the first argument. 

`run_test!("custom specification description here")`

A huge benefit to this is that when paired with auto generation of request/response examples, many example scenarios can be provided for documentation within the same `response` grouping.

NOTE: `description` is not an allowable option to pass down to a specification, so we delete it vs forwarding down to `it`.

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md
- [x] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

