### PR TITLE
Pass Metadata to HTTP Verb methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added option --spec_path to the generator command with requests as default value (https://github.com/rswag/rswag/pull/607)
 - Add support for `:getter` parameter option to explicitly define custom parameter getter method and avoid RSpec conflicts with `include` matcher and `status` method (https://github.com/rswag/rswag/pull/605)
 - Added support strict schema validation and allow to pass metadata to run_test! (https://github.com/rswag/rswag/pull/604)
+- Allow passing metadata to HTTP verb methods (https://github.com/rswag/rswag/pull/628)
 
 ### Changed
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -13,9 +13,9 @@ module Rswag
       end
 
       [:get, :post, :patch, :put, :delete, :head, :options, :trace].each do |verb|
-        define_method(verb) do |summary, &block|
-          api_metadata = { operation: { verb: verb, summary: summary } }
-          describe(verb, api_metadata, &block)
+        define_method(verb) do |summary, **metadata, &block|
+          api_metadata = { operation: { verb: verb, summary: summary } }.deep_merge(metadata)
+          describe(verb, **api_metadata, &block)
         end
       end
 

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -26,12 +26,24 @@ module Rswag
       end
 
       describe '#get|post|patch|put|delete|head|options|trace(verb, summary)' do
-        before { subject.post('Creates a blog') }
+        context 'when called without keyword arguments' do
+          before { subject.post('Creates a blog') }
 
-        it "delegates to 'describe' with 'operation' metadata" do
-          expect(subject).to have_received(:describe).with(
-            :post, operation: { verb: :post, summary: 'Creates a blog' }
-          )
+          it "delegates to 'describe' with 'operation' metadata" do
+            expect(subject).to have_received(:describe).with(
+              :post, operation: { verb: :post, summary: 'Creates a blog' }
+            )
+          end
+        end
+
+        context 'when called with keyword arguments' do
+          before { subject.post('Creates a blog', foo: 'bar') }
+
+          it "delegates to 'describe' with 'operation' metadata and provided metadata" do
+            expect(subject).to have_received(:describe).with(
+              :post, operation: { verb: :post, summary: 'Creates a blog' }, foo: 'bar'
+            )
+          end
         end
       end
 
@@ -136,20 +148,20 @@ module Rswag
         end
       end
 
-      describe '#request_body_example(value:, summary: nil, name: nil)' do 
-        context "when adding one example" do 
+      describe '#request_body_example(value:, summary: nil, name: nil)' do
+        context "when adding one example" do
           before { subject.request_body_example(value: value)}
           let(:api_metadata) { { operation: {} } }
           let(:value) { { field: 'A', another_field: 'B' } }
 
-          it "assigns the example to the metadata" do 
-            expect(api_metadata[:operation][:request_examples].length()).to eq(1) 
+          it "assigns the example to the metadata" do
+            expect(api_metadata[:operation][:request_examples].length()).to eq(1)
             expect(api_metadata[:operation][:request_examples][0]).to eq({ value: value, name: 0 })
-          end 
+          end
         end
 
-        context "when adding multiple examples with additional information" do 
-          before { 
+        context "when adding multiple examples with additional information" do
+          before {
             subject.request_body_example(value: example_one)
             subject.request_body_example(value: example_two, name: example_two_name, summary: example_two_summary)
           }
@@ -159,13 +171,13 @@ module Rswag
           let(:example_two_name) { 'example_two' }
           let(:example_two_summary) { 'An example description' }
 
-          it "assigns all examples to the metadata" do 
-            expect(api_metadata[:operation][:request_examples].length()).to eq(2) 
+          it "assigns all examples to the metadata" do
+            expect(api_metadata[:operation][:request_examples].length()).to eq(2)
             expect(api_metadata[:operation][:request_examples][0]).to eq({ value: example_one, name: 0 })
             expect(api_metadata[:operation][:request_examples][1]).to eq({ value: example_two, name: example_two_name, summary: example_two_summary })
-          end 
-        end  
-      end 
+          end
+        end
+      end
 
 
       describe '#examples(example)' do

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -155,6 +155,14 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
         let(:id) { 'invalid' }
         run_test!
       end
+
+      response '200', 'blog found - swagger_strict_schema_validation = true', swagger_strict_schema_validation: true do
+        schema '$ref' => '#/definitions/blog'
+
+        let(:id) { blog.id }
+
+        run_test!
+      end
     end
   end
 


### PR DESCRIPTION
## Problem
Metadata can't be passed into HTTP verb methods.

## Solution
Add a keyword arguments parameter to the HTTP verb methods that is passed through to `describe`.

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
n/a

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md

### Steps to Test or Reproduce
Try passing keyword arguments to an HTTP verb method.
