### PR TITLE
docs: Add providing test-app example into PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@ Links to any related issues.
 - [ ] Added tests
 - [ ] Changelog updated
 - [ ] Added documentation to README.md
+- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)
 
 ### Steps to Test or Reproduce
 Outline the steps to test or reproduce the PR here.


### PR DESCRIPTION
test-app is good for demonstration of the changes, rswag users will need to do in their codebases to use new changes.

## Problem
test-app is usually being overlooked

## Solution
Adding the action to PR checklist could help bring attention to it