### PR TITLE
Add rubocop alias config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Allow passing metadata to HTTP verb methods (https://github.com/rswag/rswag/pull/628)
+- Added configuration for RuboCop RSpec to improve detection of RSpec examples and example groups (https://github.com/rswag/rswag/pull/632)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1110,3 +1110,13 @@ parameter name: :status,
 let(:status) { nil } # will not be used in query string
 let(:filter_status) { 'one' } # `&status=one` will be provided in final query
 ```
+
+### Linting with RuboCop RSpec
+
+When you lint your RSpec spec files with `rubocop-rspec`, it will fail to detect RSpec aliases that Rswag defines.
+Make sure to use `rubocop-rspec` 2.0 or newer and add the following to your `.rubocop.yml`:
+
+```yaml
+inherit_gem:
+  rswag-specs: .rubocop_rspec_alias_config.yml
+```

--- a/cspell.json
+++ b/cspell.json
@@ -49,6 +49,8 @@
     "swaggerize",
     "tempuri",
     "tmpdir",
-    "xlink"
+    "xlink",
+    "rubocop",
+    "RuboCop"
   ]
 }

--- a/rswag-specs/.rubocop_rspec_alias_config.yml
+++ b/rswag-specs/.rubocop_rspec_alias_config.yml
@@ -1,0 +1,17 @@
+RSpec:
+  Language:
+    ExampleGroups:
+      Regular:
+        - path
+        - response
+        - get
+        - post
+        - patch
+        - put
+        - delete
+        - head
+        - options
+        - trace
+    Examples:
+      Regular:
+        - run_test!

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = 'Simplify API integration testing with a succinct rspec DSL and generate OpenAPI specification files directly from your rspec tests. More about the OpenAPI initiative here: http://spec.openapis.org/'
   s.license     = 'MIT'
 
-  s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']
+  s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
   s.add_dependency 'activesupport', '>= 3.1', '< 7.1'
   s.add_dependency 'railties', '>= 3.1', '< 7.1'


### PR DESCRIPTION
## Problem
As previously discussed in issue #138, `rubocop-rspec` flags a violation of `RSpec/EmptyExampleGroup` when using rswag-only syntax without `it`, `specify`, etc.

<img width="513" alt="Screenshot 2023-04-29 at 3 38 56 PM" src="https://user-images.githubusercontent.com/578554/235290230-5acc4187-0c49-48f3-8da2-8a4e2cfb09c7.png">


## Solution
Since the original issue was opened and closed in 2018, `rubocop-rspec` has released version 2.0, which now supports syntax extension in third-party gems. Details: https://docs.rubocop.org/rubocop-rspec/third_party_rspec_syntax_extensions.html

To resolve this issue, `rswag-specs` should come with the rubocop rspec alias config. And the README should contain instructions for users on how to enable it.

```yaml
inherit_gem:
  rswag-specs: .rubocop_rspec_alias_config.yml
```

### Examples:
- https://github.com/test-prof/test-prof/pull/199
- https://github.com/palkan/action_policy/pull/138

### Related Issues
#138

### Checklist
- [ ] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md

### Steps to Test or Reproduce
The problem can be reproduced by running rubocop-rspec against the code example from the README:

```ruby
# spec/requests/blogs_spec.rb
require 'swagger_helper'

describe 'Blogs API' do

  path '/blogs' do

    post 'Creates a blog' do
      tags 'Blogs'
      consumes 'application/json'
      parameter name: :blog, in: :body, schema: {
        type: :object,
        properties: {
          title: { type: :string },
          content: { type: :string }
        },
        required: [ 'title', 'content' ]
      }

      response '201', 'blog created' do
        let(:blog) { { title: 'foo', content: 'bar' } }
        run_test!
      end

      response '422', 'invalid request' do
        let(:blog) { { title: 'foo' } }
        run_test!
      end
    end
  end
```
