### PR TITLE
cleanup: Drop Rspec v2 support

### DIFF
--- a/rswag-specs/lib/rswag/specs.rb
+++ b/rswag-specs/lib/rswag/specs.rb
@@ -23,8 +23,7 @@ module Rswag
       @config ||= Configuration.new(RSpec.configuration)
     end
 
-    # Support Rails 3+ and RSpec 2+ (sigh!)
+    # Support Rails 3+
     RAILS_VERSION = Rails::VERSION::MAJOR
-    RSPEC_VERSION = RSpec::Core::Version::STRING.split('.').first.to_i
   end
 end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -128,25 +128,13 @@ module Rswag
 
         description ||= "returns a #{metadata[:response][:code]} response"
 
-        if RSPEC_VERSION < 3
-          ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
-          before do
-            submit_request(example.metadata)
-          end
+        before do |example|
+          submit_request(example.metadata)
+        end
 
-          it description, *args, **options do
-            assert_response_matches_metadata(metadata)
-            block.call(response) if block_given?
-          end
-        else
-          before do |example|
-            submit_request(example.metadata)
-          end
-
-          it description, *args, **options do |example|
-            assert_response_matches_metadata(example.metadata, &block)
-            example.instance_exec(response, &block) if block_given?
-          end
+        it description, *args, **options do |example|
+          assert_response_matches_metadata(example.metadata, &block)
+          example.instance_exec(response, &block) if block_given?
         end
       end
     end

--- a/rswag-specs/lib/rswag/specs/openapi_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/openapi_formatter.rb
@@ -9,11 +9,7 @@ module Rswag
     class OpenapiFormatter < ::RSpec::Core::Formatters::BaseTextFormatter
       ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for Ruby 2.6 will be dropped in v3.0') if RUBY_VERSION.start_with? '2.6'
 
-      if RSPEC_VERSION > 2
-        ::RSpec::Core::Formatters.register self, :example_group_finished, :stop
-      else
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
-      end
+      ::RSpec::Core::Formatters.register self, :example_group_finished, :stop
 
       def initialize(output, config = Rswag::Specs.config)
         @output = output
@@ -23,11 +19,7 @@ module Rswag
       end
 
       def example_group_finished(notification)
-        metadata = if RSPEC_VERSION > 2
-          notification.group.metadata
-        else
-          notification.metadata
-        end
+        metadata = notification.group.metadata
         # metadata[:document] has to be explicitly false to skip generating docs
         return if metadata[:document] == false
         return unless metadata.key?(:response)

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -16,10 +16,14 @@ namespace :rswag do
         ''
       )
 
-      t.rspec_opts = [additional_rspec_opts]
+      t.rspec_opts = [
+        '--format Rswag::Specs::OpenapiFormatter',
+        '--order defined'
+      ] << additional_rspec_opts
+
 
       if Rswag::Specs.config.swagger_dry_run
-        t.rspec_opts += ['--format Rswag::Specs::OpenapiFormatter', '--dry-run', '--order defined']
+        t.rspec_opts += ['--dry-run']
       end
     end
   end

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -18,11 +18,8 @@ namespace :rswag do
 
       t.rspec_opts = [additional_rspec_opts]
 
-      if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.rswag_dry_run
+      if Rswag::Specs.config.swagger_dry_run
         t.rspec_opts += ['--format Rswag::Specs::OpenapiFormatter', '--dry-run', '--order defined']
-      else
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
-        t.rspec_opts += ['--format Rswag::Specs::OpenapiFormatter', '--order defined']
       end
     end
   end

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.1', '< 7.2'
   s.add_dependency 'json-schema', '>= 2.2', '< 4.0'
   s.add_dependency 'railties', '>= 3.1', '< 7.2'
-  s.add_dependency 'rspec-core', '>=2.14'
-  
+  s.add_dependency 'rspec-core', '>=3.12'
+
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -237,7 +237,6 @@ module Rswag
       end
 
       describe "#run_test!" do
-        let(:rspec_version) { 3 }
         let(:api_metadata) {
           {
             response: {
@@ -247,7 +246,6 @@ module Rswag
         }
 
         before do
-          stub_const("RSPEC_VERSION", rspec_version)
           allow(subject).to receive(:before)
         end
 


### PR DESCRIPTION
## Problem
Rspec-core 2.14 is an old version and it's support is planned to be dropped in rswag 3.0.0

## Solution
Upgrading rspec-core dependency to 3.12

### This concerns this parts of the OpenAPI Specification:

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
- https://github.com/rswag/rswag/issues/611

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
