### PR TITLE
Add support for text/plain body format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix encoding of query params (https://github.com/rswag/rswag/pull/621)
+- Fix support for string body params (https://github.com/rswag/rswag/pull/639)
 
 ### Added
 

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -251,6 +251,15 @@ module Rswag
                             end
       end
 
+      def build_body_param(parameters, example)
+        body_param = parameters.select { |p| p[:in] == :body }.first
+        return nil unless body_param
+
+        raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
+
+        body_param
+      end
+
       def build_form_payload(parameters, example)
         # See http://seejohncode.com/2012/04/29/quick-tip-testing-multipart-uploads-with-rspec/
         # Rather that serializing with the appropriate encoding (e.g. multipart/form-data),
@@ -262,16 +271,6 @@ module Rswag
         Hash[tuples]
       end
 
-      def build_json_payload(parameters, example)
-        body_param = parameters.select { |p| p[:in] == :body }.first
-
-        return nil unless body_param
-
-        raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
-
-        example.send(body_param[:name]).to_json
-      end
-
       def build_raw_payload(parameters, example)
         body_param = parameters.select { |p| p[:in] == :body }.first
         return nil unless body_param
@@ -279,6 +278,10 @@ module Rswag
         raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
 
         example.send(body_param[:name])
+      end
+
+      def build_json_payload(parameters, example)
+        build_raw_payload(parameters, example)&.to_json
       end
 
       def doc_version(doc)

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -251,15 +251,6 @@ module Rswag
                             end
       end
 
-      def build_body_param(parameters, example)
-        body_param = parameters.select { |p| p[:in] == :body }.first
-        return nil unless body_param
-
-        raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
-
-        body_param
-      end
-
       def build_form_payload(parameters, example)
         # See http://seejohncode.com/2012/04/29/quick-tip-testing-multipart-uploads-with-rspec/
         # Rather that serializing with the appropriate encoding (e.g. multipart/form-data),

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -242,11 +242,13 @@ module Rswag
         content_type = request[:headers]['CONTENT_TYPE']
         return if content_type.nil?
 
-        if ['application/x-www-form-urlencoded', 'multipart/form-data'].include?(content_type)
-          request[:payload] = build_form_payload(parameters, example)
-        else
-          request[:payload] = build_json_payload(parameters, example)
-        end
+        request[:payload] = if ['application/x-www-form-urlencoded', 'multipart/form-data'].include?(content_type)
+                              build_form_payload(parameters, example)
+                            elsif content_type == 'application/json'
+                              build_json_payload(parameters, example)
+                            else
+                              build_raw_payload(parameters, example)
+                            end
       end
 
       def build_form_payload(parameters, example)
@@ -268,6 +270,15 @@ module Rswag
         raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
 
         example.send(body_param[:name]).to_json
+      end
+
+      def build_raw_payload(parameters, example)
+        body_param = parameters.select { |p| p[:in] == :body }.first
+        return nil unless body_param
+
+        raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])
+
+        example.send(body_param[:name])
       end
 
       def doc_version(doc)

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -413,6 +413,18 @@ module Rswag
               )
             end
           end
+
+          context 'plain text payload' do
+            before do
+              metadata[:operation][:consumes] = ['text/plain']
+              metadata[:operation][:parameters] = [{ name: 'comment', in: :body, schema: { type: 'string' } }]
+              allow(example).to receive(:comment).and_return('plain text comment')
+            end
+
+            it 'keeps payload as a raw string data' do
+              expect(request[:payload]).to eq('plain text comment')
+            end
+          end
         end
 
         context 'produces content' do

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -417,7 +417,7 @@ module Rswag
           context 'plain text payload' do
             before do
               metadata[:operation][:consumes] = ['text/plain']
-              metadata[:operation][:parameters] = [{ name: 'comment', in: :body, schema: { type: 'string' } }]
+              metadata[:operation][:parameters] = [{ name: 'comment', in: :body, type: 'string' }]
               allow(example).to receive(:comment).and_return('plain text comment')
             end
 


### PR DESCRIPTION
## Problem
Unable to send request "string" body format correctly because it get serialized as JSON even if the content type is `text/plain`

## Solution
- Serialize to `JSON` only parameter body payload if  consumes  `application/json`

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
- https://github.com/rswag/rswag/issues/181

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
