### PR TITLE
feature: global setting to set additionalProperties as false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Allow passing metadata to HTTP verb methods (https://github.com/rswag/rswag/pull/628)
 - Added configuration for RuboCop RSpec to improve detection of RSpec examples and example groups (https://github.com/rswag/rswag/pull/632)
-- Added global setting for `additionalProperties` to defalt to false unless explicitly defined (https://github.com/rswag/rswag/compare/master...MichaelAlexanderBanuelos:rswag:feature/stricter-schemas?expand=1)
+- Added global setting for `additionalProperties` to defalt to false unless explicitly defined (https://github.com/rswag/rswag/pull/644)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Allow passing metadata to HTTP verb methods (https://github.com/rswag/rswag/pull/628)
 - Added configuration for RuboCop RSpec to improve detection of RSpec examples and example groups (https://github.com/rswag/rswag/pull/632)
+- Added global setting for `additionalProperties` to defalt to false unless explicitly defined (https://github.com/rswag/rswag/compare/master...MichaelAlexanderBanuelos:rswag:feature/stricter-schemas?expand=1)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -320,9 +320,11 @@ describe 'Blogs API' do
 end
 ```
 
-### Strict schema validation
+### Additional Properties
 
-By default, `additionalProperties` will be set to true. This allows your schemas to pass even if undocumented keys show up in the response. There is a global setting to turn on strict validation, but strict validation makes all fields required and may not be what you are looking for. If you want optional fields, but only documented fields to show up then this is the setting you are looking for.
+By default, `additionalProperties` will be set to true. This allows your schemas to pass even if undocumented keys show up in the response. There is a global setting in `rswag` to turn on strict validation within `JSON::Validator`, but strict validation makes all fields required and may not be what you are looking for. 
+
+This is a global setting that will set `addtionalProperties` to false for all schemas unless explicitly defined. There is only a global setting as if you want to change it per schema or test you can just set `additionalProperties` manually there. If you want optional fields, but only documented fields to show up in your response then this is the setting you are looking for.
 
 ```ruby
 # spec/swagger_helper.rb

--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ describe 'Blogs API' do
 end
 ```
 
+### Strict schema validation
+
+By default, `additionalProperties` will be set to true. This allows your schemas to pass even if undocumented keys show up in the response. There is a global setting to turn on strict validation, but strict validation makes all fields required and may not be what you are looking for. If you want optional fields, but only documented fields to show up then this is the setting you are looking for.
+
+```ruby
+# spec/swagger_helper.rb
+RSpec.configure do |config|
+  config.disallow_additional_properties = true
+end
+```
+
 ### Null Values ###
 
 This library is currently using JSON::Draft4 for validation of response models. Nullable properties can be supported with the non-standard property 'x-nullable' to a definition to allow null/nil values to pass. Or you can add the new standard ```nullable``` property to a definition.

--- a/rswag-specs/lib/rswag/specs.rb
+++ b/rswag-specs/lib/rswag/specs.rb
@@ -15,6 +15,7 @@ module Rswag
       c.add_setting :swagger_dry_run
       c.add_setting :swagger_format
       c.add_setting :swagger_strict_schema_validation
+      c.add_setting :disallow_additional_properties
       c.extend ExampleGroupHelpers, type: :request
       c.include ExampleHelpers, type: :request
     end

--- a/rswag-specs/lib/rswag/specs/configuration.rb
+++ b/rswag-specs/lib/rswag/specs/configuration.rb
@@ -59,6 +59,10 @@ module Rswag
       def swagger_strict_schema_validation
         @swagger_strict_schema_validation ||= (@rspec_config.swagger_strict_schema_validation || false)
       end
+
+      def disallow_additional_properties
+        @disallow_additional_properties ||= (@rspec_config.disallow_additional_properties || false)
+      end
     end
 
     class ConfigurationError < StandardError; end

--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -57,10 +57,11 @@ module Rswag
 
         version = @config.get_swagger_doc_version(metadata[:swagger_doc])
         schemas = definitions_or_component_schemas(swagger_doc, version)
-
+        schema_options = additional_properties(response_schema)
         validation_schema = response_schema
           .merge('$schema' => 'http://tempuri.org/rswag/specs/extended_schema')
           .merge(schemas)
+          .merge(schema_options)
 
         validation_options = validation_options_from(metadata)
 
@@ -79,6 +80,14 @@ module Rswag
         )
 
         { strict: is_strict }
+      end
+
+      def additional_properties(schema)
+        return { additionalProperties: schema[:additionalProperties] } unless schema[:additionalProperties].nil?
+
+        return {} unless @config.disallow_additional_properties
+
+        { additionalProperties: false }
       end
 
       def definitions_or_component_schemas(swagger_doc, version)


### PR DESCRIPTION
## Problem
Currently, Rswag does not provide a global setting to control the `additionalProperties` behavior in OpenAPI schemas. This means that `additionalProperties` is set to `true` by default, allowing any additional properties to be added to objects without validation. This can lead to unexpected data inconsistencies and potential security vulnerabilities. 

This provides a solution for issues like #402

## Solution
This pull request introduces a new global setting `disallow_additional_properties` in Rswag that allows users to set `additionalProperties: false` on all schemas by default, unless they have already been defined. This setting provides better control and enforces stricter validation on object properties throughout the API documentation.

Alternatively if we decide to not use this change or something similar, folks can still manually set `additionalProperties: false` but when working in a larger codebase its easy to forget these things.

### This concerns these parts of the OpenAPI Specification:
* [Data Types](https://spec.openapis.org/oas/v3.1.0#data-types)
* [Schema Object](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
N/A

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
1. Configure the new global setting for `disallow_additional_properties: true`.
3. Run the swagger tests and verify that responses with undocumented keys fail the test.
