### PR TITLE
Don't call outer `run_test!` API requests inside nested context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- API requests from `run_test!` will not be repeated within nested contexts (https://github.com/rswag/rswag/pull/652)
+
 ### Fixed
 
 ### Documentation

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -139,11 +139,8 @@ module Rswag
             block.call(response) if block_given?
           end
         else
-          before do |example|
-            submit_request(example.metadata)
-          end
-
           it description, *args, **options do |example|
+            submit_request(example.metadata)
             assert_response_matches_metadata(example.metadata, &block)
             example.instance_exec(response, &block) if block_given?
           end

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -20,7 +20,15 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
 
       response '201', 'blog created' do
         # schema '$ref' => '#/definitions/blog'
-        run_test!
+        run_test! 'it creates one blog post' do
+          expect(Blog.count).to eq(1)
+        end
+
+        context 'with a nested context' do
+          run_test! 'it still creates one blog post' do
+            expect(Blog.count).to eq(1)
+          end
+        end
       end
 
       response "422", "invalid request" do


### PR DESCRIPTION
## Problem
When using a nested RSpec `context`, the outer `run_test!` cause unexpected API calls.

## Solution
Avoid touching the `before` during `run_test!` because that causes the API calls to be inherited.

### Related Issues
I searched for issues in GitHub but was not able to find any mention of this problem.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
  - Not sure if I should do this as the current readme makes no mention of `context`
- [x] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)
  - It's a fix for testing, so the test is itself an example of using it.

### Steps to Test or Reproduce
Run the changed specs without the change to example_group_helpers.rb and you'll have a `.count` of 2: one for line 23 and a second for line 28.