### PR TITLE
Improving generation of  OAS3.0 `requestBody` from `parameter`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,9 @@ after do |example|
 end
 ```
 
+Note you will need to disable the `--dry-run` option for Rspec 3.0.0 or higher to 
+run the after callback. See below for more information.
+
 #### Dry Run Option ####
 
 The `--dry-run` option is enabled by default for Rspec 3, but if you need to

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -197,7 +197,8 @@ module Rswag
 
       def parse_parameters(endpoint, mime_list)
         parameters = endpoint[:parameters]
-        # There can only be 1 body!
+        # There can only be 1 body parameter in Swagger 2.0, so while in OAS3 we interpret
+        # body parameters as formData, only consider the first body we encounter.
         schema_param = parameters.find { |p| (p[:in] == :body) && p[:schema] }
         parse_body_parameter(endpoint, schema_param, mime_list) if schema_param
 
@@ -225,21 +226,31 @@ module Rswag
       def parse_parameter_schema(endpoint, parameter, mime_list)
         # Only add if there are any body parameters and not already defined
         add_request_body(endpoint)
-        set_request_body_required(endpoint, parameter)
 
         mime_list.each do |mime|
           endpoint[:requestBody][:content][mime] ||= {}
           mime_config = endpoint[:requestBody][:content][mime]
           set_parameter_schema(parameter)
-          set_mime_config(mime_config, parameter)
-          set_mime_examples(mime_config, endpoint)
+          # Only parse parameters if there has not already been a reference object set
+          if !mime_config[:schema] || mime_config.dig(:schema, :properties)
+            set_mime_config(mime_config, parameter)
+            set_mime_examples(mime_config, endpoint)
+          end
         end
+
+        set_request_body_required(endpoint, mime_list)
       end
 
       # FIXME: If any are `required` then the body is set to `required` but this assumption may not hold in reality as
-        # you could have optional body, but if body is provided then some properties are required.
-      def set_request_body_required(endpoint, parameter)
-        required = parameter[:required] || parameter.dig(:schema, :required)
+      # you could have optional body, but if body is provided then some properties are required.
+      # Also could just parse this info at time of parsing parameters
+      def set_request_body_required(endpoint, mime_list)
+        required = mime_list.any? do |mime|
+          mime_config = endpoint[:requestBody][:content][mime]
+          mime_config.any? do |_mime, config|
+            config[:required] || config.dig(:schema, :required) || config[:properties]&.any? { |_k, s| s[:required] }
+          end
+        end
         endpoint[:requestBody][:required] = true if required
       end
 
@@ -256,7 +267,7 @@ module Rswag
           set_mime_encoding(mime_config, parameter)
         end
       end
-      
+
       def set_mime_encoding(mime_config, parameter)
         return unless parameter[:encoding]
         encoding = parameter[:encoding].dup
@@ -264,7 +275,7 @@ module Rswag
         mime_config[:encoding] ||= {}
         mime_config[:encoding][parameter[:name]] = encoding
       end
-      
+
       def set_mime_examples(mime_config, endpoint)
         examples = endpoint[:request_examples]
         return unless examples

--- a/test-app/app/controllers/auth_tests_controller.rb
+++ b/test-app/app/controllers/auth_tests_controller.rb
@@ -12,6 +12,11 @@ class AuthTestsController < ApplicationController
     head :no_content
   end
 
+  def bearer
+    return head :unauthorized unless authenticate_bearer
+    head :no_content
+  end
+
   # POST /auth-tests/basic-and-api-key
   def basic_and_api_key
     return head :unauthorized unless authenticate_basic and authenticate_api_key
@@ -26,5 +31,11 @@ class AuthTestsController < ApplicationController
 
   def authenticate_api_key
     params['api_key'] == 'foobar'
+  end
+
+  def authenticate_bearer
+    authenticate_with_http_token do |token, _options|
+      token == 'foobar'
+    end
   end
 end

--- a/test-app/config/routes.rb
+++ b/test-app/config/routes.rb
@@ -7,6 +7,7 @@ TestApp::Application.routes.draw do
 
   post 'auth-tests/basic', to: 'auth_tests#basic'
   post 'auth-tests/api-key', to: 'auth_tests#api_key'
+  post 'auth-tests/bearer', to: 'auth_tests#bearer'
   post 'auth-tests/basic-and-api-key', to: 'auth_tests#basic_and_api_key'
 
   resources :stubs

--- a/test-app/spec/integration/auth_tests_spec.rb
+++ b/test-app/spec/integration/auth_tests_spec.rb
@@ -43,6 +43,24 @@ RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' 
     end
   end
 
+  path '/auth-tests/bearer' do
+    post 'Authenticates with an api key' do
+      tags 'Auth Tests'
+      operationId 'testBearerToken'
+      security [bearer: []]
+
+      response '204', 'Valid credentials' do
+        let(:Authorization) { 'Bearer foobar' }
+        run_test!
+      end
+
+      response '401', 'Invalid credentials' do
+        let(:Authorization) { 'Bearer barFoo' }
+        run_test!
+      end
+    end
+  end
+
   path '/auth-tests/basic-and-api-key' do
     post 'Authenticates with basic auth and api key' do
       tags 'Auth Tests'

--- a/test-app/spec/swagger_helper.rb
+++ b/test-app/spec/swagger_helper.rb
@@ -80,6 +80,10 @@ RSpec.configure do |config|
             type: :apiKey,
             name: 'api_key',
             in: :query
+          },
+          bearer: {
+            type: :http,
+            scheme: :bearer
           }
         }
       }


### PR DESCRIPTION
## Problem / Solution

The handling of path `parameter`s does not currently generate OAS3.0 `requestBody` correctly in some cases. This PR proposes a refactoring and updates to `SwaggerFormatter` to improve translation of the DSL defined parameters. 

It takes the approach that any parameter defined as `in: :body` is handled differently to parameters that are `in: :formData`. A request can only have a single `body` parameter but can have multiple `formData` parameters.

It also adds support for translating a `:file`parameter to the new OAS3.0 schema and some tests for the http `bearer` security schema.

I started this as I wanted to specify parameter for multipart requestBody (including file upload with multiple possible content types) and ended up making these changes so far. 

I thought to now open a draft PR for any early feedback and then hopefully update until its good to go.

### This concerns this parts of the OpenAPI Specification:

* [requestBody](https://swagger.io/docs/specification/describing-request-body/)
* [File upload](https://swagger.io/docs/specification/describing-request-body/file-upload/)

Note that file upload definitions improved in OAS3.1 but this PR does not yet attempt to support that

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [ ] OAS3.1

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)


---

Thanks so much for all the work on `rswag` over the years, its great!
