### PR TITLE
Update rswag-specs dependency on json-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+Relaxed the dependency on json-schema, allowing for updates including support for allPropertiesRequired and noPropertiesRequired options
+
 ### Fixed
 
 - Add missing link to Content Security Policy (https://github.com/rswag/rswag/pull/619)

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
   s.add_dependency 'activesupport', '>= 3.1', '< 7.2'
-  s.add_dependency 'json-schema', '>= 2.2', '< 4.0'
+  s.add_dependency 'json-schema', '>= 2.2', '< 5.0'
   s.add_dependency 'railties', '>= 3.1', '< 7.2'
   s.add_dependency 'rspec-core', '>=2.14'
-  
+
   s.add_development_dependency 'simplecov', '=0.21.2'
 end


### PR DESCRIPTION
A review of the changelog on json-schema doesn't reveal any breaking changes that should affect rswag-specs, and the test suite continues to pass.
