### PR TITLE
Fix path expansion

### DIFF
--- a/rswag-api/lib/rswag/api/middleware.rb
+++ b/rswag-api/lib/rswag/api/middleware.rb
@@ -15,7 +15,7 @@ module Rswag
         path = env['PATH_INFO']
         # Sanitize the filename for directory traversal by expanding, and ensuring
         # its starts with the root directory.
-        filename = File.expand_path(path, @config.resolve_swagger_root(env))
+        filename = File.expand_path(File.join(@config.resolve_swagger_root(env), path))
         unless filename.start_with? @config.resolve_swagger_root(env)
           return @app.call(env)
         end


### PR DESCRIPTION
Reverts part of efd4ea4


## Problem
The dir_string is ignored if file_name starts with a slash. In our case of retrieving the HTTP request path from env, path will start with a slash. This broke swagger file resolution.

## Solution
Revert back to the `File.join` method which is safer in case of risk of additional slashes.

### This concerns this parts of the OpenAPI Specification:
-

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
https://github.com/rswag/rswag/pull/654#discussion_r1262688116
#653

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
