### PR TITLE
Fix middleware checking of swagger root

### DIFF
--- a/rswag-api/lib/rswag/api/middleware.rb
+++ b/rswag-api/lib/rswag/api/middleware.rb
@@ -16,7 +16,7 @@ module Rswag
         # Sanitize the filename for directory traversal by expanding, and ensuring
         # its starts with the root directory.
         filename = File.expand_path(File.join(@config.resolve_swagger_root(env), path))
-        unless filename.start_with? @config.resolve_swagger_root(env)
+        unless filename.start_with? @config.resolve_swagger_root(env).to_s
           return @app.call(env)
         end
 

--- a/rswag-api/spec/rswag/api/middleware_spec.rb
+++ b/rswag-api/spec/rswag/api/middleware_spec.rb
@@ -35,6 +35,17 @@ module Rswag
             expect(response[1]).to include( 'Content-Type' => 'application/json')
             expect(response[2].join).to include('"title":"API V1"')
           end
+
+          context 'configured with a Pathname similar to `Rails.root.join("swagger")`' do
+            let(:swagger_root_pathname) { Pathname.new(swagger_root) }
+
+            before { config.swagger_root = swagger_root_pathname }
+
+            it 'returns a 200 status' do
+              expect(response.length).to eql(3)
+              expect(response.first).to eql('200')
+            end
+          end
         end
 
         context 'when swagger_headers is configured' do


### PR DESCRIPTION

## Problem


When Swagger is configured with a pathname as swagger root then it raised:

```
TypeError (no implicit conversion of Pathname into String):

rswag-api (2.10.1) lib/rswag/api/middleware.rb:20:in `start_with?'
```


## Solution

Converting the swagger root to string before comparing it with another string makes it more robust.

### This concerns this parts of the OpenAPI Specification:
No.

### The changes I made are compatible with:

No changes to compatibility.

### Related Issues

* #665

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
```
$ cat config/initializers/rswag_api.rb
```
Pay attention to the swagger_root.
```rb
# frozen_string_literal: true

Rswag::Api.configure do |config|
  # Specify a root folder where Swagger JSON files are located
  # This is used by the Swagger middleware to serve requests for API descriptions
  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
  # that it's configured to generate files in the same folder
  config.swagger_root = Rails.root.join("swagger")

  # Inject a lamda function to alter the returned Swagger prior to serialization
  # The function will have access to the rack env for the current request
  # For example, you could leverage this to dynamically assign the "host" property
  #
  # config.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
end
```
