### PR TITLE
bump swagger-ui-dist to 5.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Bump "swagger-ui-dist" to "5.9.4" in rswag-ui
+
 ### Documentation
 
 ## [2.10.1]

--- a/rswag-ui/package-lock.json
+++ b/rswag-ui/package-lock.json
@@ -8,13 +8,13 @@
       "name": "rswag-ui",
       "version": "1.0.1",
       "dependencies": {
-        "swagger-ui-dist": "5.2.0"
+        "swagger-ui-dist": "5.9.0"
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.2.0.tgz",
-      "integrity": "sha512-rLvJBgualxNZcwKOmTFzy4zF1nHy+3S0pUDDR/ageDRZgi8aITSe7pVYiAy03xGQZtqEifjwEtHQE+eF14gveg=="
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.9.0.tgz",
+      "integrity": "sha512-NUHSYoe5XRTk/Are8jPJ6phzBh3l9l33nEyXosM17QInoV95/jng8+PuSGtbD407QoPf93MH3Bkh773OgesJpA=="
     }
   }
 }

--- a/rswag-ui/package-lock.json
+++ b/rswag-ui/package-lock.json
@@ -8,13 +8,13 @@
       "name": "rswag-ui",
       "version": "1.0.1",
       "dependencies": {
-        "swagger-ui-dist": "5.9.0"
+        "swagger-ui-dist": "5.9.4"
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.9.0.tgz",
-      "integrity": "sha512-NUHSYoe5XRTk/Are8jPJ6phzBh3l9l33nEyXosM17QInoV95/jng8+PuSGtbD407QoPf93MH3Bkh773OgesJpA=="
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.9.4.tgz",
+      "integrity": "sha512-Ppghvj6Q8XxH5xiSrUjEeCUitrasGtz7v9FCUIBR/4t89fACQ4FnUT9D0yfodUYhB+PrCmYmxwe/2jTDLslHDw=="
     }
   }
 }

--- a/rswag-ui/package-lock.json
+++ b/rswag-ui/package-lock.json
@@ -1,13 +1,20 @@
 {
   "name": "rswag-ui",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
+  "version": "1.0.1",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "swagger-ui-dist": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.3.tgz",
-      "integrity": "sha512-WvfPSfAAMlE/sKS6YkW47nX/hA7StmhYnAHc6wWCXNL0oclwLj6UXv0hQCkLnDgvebi0MEV40SJJpVjKUgH1IQ=="
+  "packages": {
+    "": {
+      "name": "rswag-ui",
+      "version": "1.0.1",
+      "dependencies": {
+        "swagger-ui-dist": "5.2.0"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.2.0.tgz",
+      "integrity": "sha512-rLvJBgualxNZcwKOmTFzy4zF1nHy+3S0pUDDR/ageDRZgi8aITSe7pVYiAy03xGQZtqEifjwEtHQE+eF14gveg=="
     }
   }
 }

--- a/rswag-ui/package.json
+++ b/rswag-ui/package.json
@@ -1,8 +1,8 @@
 {
   "name": "rswag-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "4.1.3"
+    "swagger-ui-dist": "5.2.0"
   }
 }

--- a/rswag-ui/package.json
+++ b/rswag-ui/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.1",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "5.2.0"
+    "swagger-ui-dist": "5.9.0"
   }
 }

--- a/rswag-ui/package.json
+++ b/rswag-ui/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.1",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "5.9.0"
+    "swagger-ui-dist": "5.9.4"
   }
 }


### PR DESCRIPTION
## Problem
Swagger UI was 4.1.3. The newest version is 5.9.0. This is just a dependency bump. Tests were locally fine except pending examples. "Pending: (Failures listed here are expected and do not affect your suite's status)" I guess PR should be fine then.

####################
Unit Tests
####################
```
##### rswag-api #####
..............

Finished in 0.00952 seconds (files took 1.53 seconds to load)
14 examples, 0 failures

Coverage report generated for RSpec to /Users/bijan/dev/ruby/rswag/rswag-api/coverage. 51 / 51 LOC (100.0%) covered.
##### rswag-specs #####
..................................WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/bijan/dev/ruby/rswag/rswag-specs/spec/rswag/specs/request_factory_spec.rb:44:in `block (5 levels) in <module:Specs>'.
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/bijan/dev/ruby/rswag/rswag-specs/spec/rswag/specs/request_factory_spec.rb:45:in `block (5 levels) in <module:Specs>'.
......................................................................................

Finished in 0.06021 seconds (files took 0.34182 seconds to load)
120 examples, 0 failures

Coverage report generated for RSpec to /Users/bijan/dev/ruby/rswag/rswag-specs/coverage. 519 / 545 LOC (95.23%) covered.
##### rswag-ui #####
......

Finished in 0.01082 seconds (files took 0.26819 seconds to load)
6 examples, 0 failures

Coverage report generated for RSpec to /Users/bijan/dev/ruby/rswag/rswag-ui/coverage. 36 / 39 LOC (92.31%) covered.
####################
Integration Tests
####################

##### test-app #####
== 20160218212104 CreateBlogs: migrating ======================================
-- create_table(:blogs, {:id=>:integer})
   -> 0.0010s
== 20160218212104 CreateBlogs: migrated (0.0010s) =============================

*.......................*......*DEPRECATION WARNING: Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0 (called from block (2 levels) in <top (required)> at /Users/bijan/dev/ruby/rswag/test-app/spec/rake/rswag_specs_swaggerize_spec.rb:14)
/Users/bijan/.rbenv/versions/2.7.6/bin/ruby -I/Users/bijan/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rspec-core-3.12.2/lib:/Users/bijan/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rspec-support-3.12.1/lib /Users/bijan/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rspec-core-3.12.2/exe/rspec --pattern spec/requests/\*\*/\*_spec.rb,\ spec/api/\*\*/\*_spec.rb,\ spec/integration/\*\*/\*_spec.rb --format Rswag::Specs::SwaggerFormatter --order defined
Generating Swagger docs ...
Swagger doc generated at /Users/bijan/dev/ruby/rswag/test-app/swagger/v1/swagger.json
Swagger doc generated at /Users/bijan/dev/ruby/rswag/test-app/swagger/v3/openapi.json

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Generated OpenApi Media Types /stubs get OK declares output as application/json
     # Not yet implemented?
     Failure/Error: expect(tree).to have_key('application/json')
       expected nil to respond to `has_key?`
     # ./spec/integration/openapi3_spec.rb:106:in `block (6 levels) in <top (required)>'

  2) Generated OpenApi Request Body /stubs post OK declares requestBody is required
     # This output is massaged in SwaggerFormatter#stop, and isn't quite ready here to assert
     Failure/Error: expect(tree[:required]).to eq(true)
     
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./spec/integration/openapi3_spec.rb:199:in `block (6 levels) in <top (required)>'

Finished in 0.27787 seconds (files took 0.78128 seconds to load)
31 examples, 0 failures, 2 pending

Coverage report generated for RSpec to /Users/bijan/dev/ruby/rswag/test-app/coverage. 66 / 68 LOC (97.06%) covered.
.

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) swagger-ui browsing api-docs
     # Needs work to run on others' machines
     # ./spec/features/swagger_ui_spec.rb:5

  2) Generated OpenApi Media Types /stubs get OK declares output as application/json
     # Not yet implemented?
     Failure/Error: expect(tree).to have_key('application/json')
       expected nil to respond to `has_key?`
     # ./spec/integration/openapi3_spec.rb:106:in `block (6 levels) in <top (required)>'

  3) Generated OpenApi Request Body /stubs post OK declares requestBody is required
     # This output is massaged in SwaggerFormatter#stop, and isn't quite ready here to assert
     Failure/Error: expect(tree[:required]).to eq(true)
     
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./spec/integration/openapi3_spec.rb:199:in `block (6 levels) in <top (required)>'

Finished in 1.58 seconds (files took 0.81148 seconds to load)
33 examples, 0 failures, 3 pending

Coverage report generated for RSpec to /Users/bijan/dev/ruby/rswag/test-app/coverage. 66 / 68 LOC (97.06%) covered.

```
