### PR TITLE
Fix encoding of query params when openapi is v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fix encoding query parameter for OpenApi v3 (https://github.com/rswag/rswag/pull/671)
+
 ### Added
 
 ### Changed

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -173,6 +173,8 @@ module Rswag
                           end
               return "#{escaped_name}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(separator)
             end
+          when :string
+            return "#{escaped_name}=#{CGI.escape(value.to_s)}"
           else
             return "#{name}=#{value}"
           end

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -171,6 +171,22 @@ module Rswag
               expect(request[:path]).to eq('/blogs?date_time=2001-02-03T04%3A05%3A06-07%3A00')
             end
           end
+
+          context 'openapi 3.0.1' do
+            let(:swagger_doc) { { openapi: '3.0.1' } }
+            context 'parameter type is defined as schema: { type: :string }' do
+              before do
+                metadata[:operation][:parameters] = [
+                  { name: 'date_time', in: :query, schema: { type: :string }, format: :datetime, }
+                ]
+                allow(example).to receive(:date_time).and_return(date_time)
+              end
+
+              it 'formats the datetime properly' do
+                expect(request[:path]).to eq('/blogs?date_time=2001-02-03T04%3A05%3A06-07%3A00')
+              end
+            end
+          end
         end
 
         context "'query' parameters of type 'object'" do


### PR DESCRIPTION
## Problem
URL encoding is not processed correctly when I define a string query parameter as `{ schema: { type: :string } }` in OpenAPI v3. This issue occurs even if I define the schema as simply `{ type: :string }` when I have multiple test cases. This is because `{ type: :string }` is automatically converted to `{ schema: { type: :string } }` after one test case finishes and before the next one starts.

## Solution
Update `build_query_string_part` and handle query parameter defined as `{ schema: { type: :string } }`

### This concerns this parts of the OpenAPI Specification:

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/606#issuecomment-1664379381

### Checklist
- [x] Added tests
- [x] Changelog updated
I didn't update readme because this is bug fix

### Steps to Test or Reproduce
Add a query parameter with `{ schema: { type: :string } }` that is in datetime format. Before this PR, the '+' symbol in the parameters would be replaced with a whitespace after encoding.