### PR TITLE
Upgrade json-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Changed
+- Update `json-schema` dependency to support 4.0 version (TODO)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Changed
-- Update `json-schema` dependency to support 4.0 version (TODO)
+- Update `json-schema` dependency to support 4.0 version (https://github.com/rswag/rswag/pull/675)
 
 ### Documentation
 

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 3.1', '< 7.1'
   s.add_dependency 'railties', '>= 3.1', '< 7.1'
-  s.add_dependency 'json-schema', '>= 2.2', '< 4.0'
+  s.add_dependency 'json-schema', '>= 2.2', '~> 4.0'
   s.add_dependency 'rspec-core', '>=2.14'
-  
+
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -2,23 +2,22 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2016_02_18_212104) do
-
+ActiveRecord::Schema[7.0].define(version: 2016_02_18_212104) do
   create_table "blogs", force: :cascade do |t|
     t.string "title"
     t.text "content"
     t.string "thumbnail"
     t.string "status"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
   end
 
 end

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -14,7 +14,9 @@
         "operationId": "testBasicAuth",
         "security": [
           {
-            "basic_auth": []
+            "basic_auth": [
+
+            ]
           }
         ],
         "responses": {
@@ -36,7 +38,9 @@
         "operationId": "testApiKey",
         "security": [
           {
-            "api_key": []
+            "api_key": [
+
+            ]
           }
         ],
         "responses": {
@@ -58,8 +62,12 @@
         "operationId": "testBasicAndApiKey",
         "security": [
           {
-            "basic_auth": [],
-            "api_key": []
+            "basic_auth": [
+
+            ],
+            "api_key": [
+
+            ]
           }
         ],
         "responses": {
@@ -80,7 +88,9 @@
         ],
         "description": "Creates a new blog from provided data",
         "operationId": "createBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "201": {
             "description": "blog created"
@@ -157,7 +167,9 @@
         ],
         "description": "Creates a flexible blog from provided data",
         "operationId": "createFlexibleBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "201": {
             "description": "flexible blog created",
@@ -215,7 +227,7 @@
         "operationId": "getBlog",
         "responses": {
           "200": {
-            "description": "blog found",
+            "description": "blog found - swagger_strict_schema_validation = true",
             "headers": {
               "ETag": {
                 "type": "string"
@@ -287,7 +299,9 @@
         ],
         "description": "Upload a thumbnail for specific blog by id",
         "operationId": "uploadThumbnailBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "200": {
             "description": "blog updated"
@@ -309,8 +323,11 @@
   },
   "servers": [
     {
-      "url": "https://{defaultHost}",
+      "url": "{protocol}://{defaultHost}",
       "variables": {
+        "protocol": {
+          "default": "https"
+        },
         "defaultHost": {
           "default": "www.example.com"
         }


### PR DESCRIPTION
## Problem
To extend the rswag with changes on the strictnesses of schemas we need to use the new version of https://github.com/voxpupuli/json-schema/pull/494

## Solution
Upgrade the `json-schema` gem as the first step. It seems there are no breaking changes affecting rswag. https://github.com/voxpupuli/json-schema/commit/f5071e13ab037882dbb3725eb7915e1868a57f86

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
https://github.com/rswag/rswag/pull/604#issuecomment-1641941197
https://github.com/rswag/rswag/issues/666

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
