### PR TITLE
Update dependencies to support Rails 7.1

### DIFF
--- a/rswag-api/rswag-api.gemspec
+++ b/rswag-api/rswag-api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']
 
-  s.add_dependency 'railties', '>= 3.1', '< 7.1'
-  
+  s.add_dependency 'railties', '>= 3.1', '< 7.2'
+
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
-  s.add_dependency 'activesupport', '>= 3.1', '< 7.1'
-  s.add_dependency 'railties', '>= 3.1', '< 7.1'
+  s.add_dependency 'activesupport', '>= 3.1', '< 7.2'
   s.add_dependency 'json-schema', '>= 2.2', '< 4.0'
+  s.add_dependency 'railties', '>= 3.1', '< 7.2'
   s.add_dependency 'rspec-core', '>=2.14'
   
   s.add_development_dependency 'simplecov', '=0.21.2'

--- a/rswag-ui/rswag-ui.gemspec
+++ b/rswag-ui/rswag-ui.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,node_modules}/**/*') + ['MIT-LICENSE', 'Rakefile' ]
 
-  s.add_dependency 'actionpack', '>=3.1', '< 7.1'
-  s.add_dependency 'railties', '>= 3.1', '< 7.1'
+  s.add_dependency 'actionpack', '>=3.1', '< 7.2'
+  s.add_dependency 'railties', '>= 3.1', '< 7.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end


### PR DESCRIPTION
## Problem
Rails 7.1 has been officially released, I'm updating my project from Rails 7.0 to 7.1 but I found some dependency issues.

## Solution
Updating dependencies for railties and actionpack 

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/676

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
