### PR TITLE
Permit loading the Date class when loading YAML files

### DIFF
--- a/rswag-api/lib/rswag/api/middleware.rb
+++ b/rswag-api/lib/rswag/api/middleware.rb
@@ -48,7 +48,8 @@ module Rswag
       end
 
       def load_yaml(filename)
-        YAML.safe_load(File.read(filename))
+        # permitted_classes: [Date] works around https://github.com/ruby/psych/issues/262
+        YAML.safe_load(File.read(filename), permitted_classes: [Date])
       end
 
       def load_json(filename)

--- a/rswag-api/spec/rswag/api/fixtures/swagger/v1/swagger.yml
+++ b/rswag-api/spec/rswag/api/fixtures/swagger/v1/swagger.yml
@@ -2,4 +2,16 @@ swagger: '2.0'
 info:
   title: API V1
   version: v1
-paths: {}
+paths:
+  "foo":
+    put:
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                first:
+                  value:
+                    foo_date: 2023-10-25
+                  
+              


### PR DESCRIPTION
Workaround for rswag/rswag#562

## Problem
RSwag generates YAML with strings that look like Dates but are not. This breaks parsing because Dates are not a permitted class for loading.

## Solution
Permit loading the Date class

### This concerns this parts of the OpenAPI Specification:
N/A

### The changes I made are compatible with:
N/A

### Related Issues
#562
[ruby/psych/issues#262
](https://github.com/ruby/psych/issues/262)

### Checklist
- [X] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
`bundle exec rspec rswag-api/spec/`