### PR TITLE
Factor out query param serialization into classes

### DIFF
--- a/rswag-specs/lib/rswag/specs/query_serializers/collections/multi_serializer.rb
+++ b/rswag-specs/lib/rswag/specs/query_serializers/collections/multi_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Collections
+        class MultiSerializer
+          def serialize(name, value)
+            value.map { |v| "#{CGI.escape(name.to_s)}=#{CGI.escape(v.to_s)}" }.join("&")
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/lib/rswag/specs/query_serializers/collections/xsv_serializer.rb
+++ b/rswag-specs/lib/rswag/specs/query_serializers/collections/xsv_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Collections
+        class XSVSerializer
+          def initialize(sep)
+            @sep = sep
+          end
+
+          def serialize(name, value)
+            "#{CGI.escape(name.to_s)}=#{value.map { |v| CGI.escape(v.to_s) }.join(@sep)}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/lib/rswag/specs/query_serializers/primitive_serializer.rb
+++ b/rswag-specs/lib/rswag/specs/query_serializers/primitive_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      class PrimitiveSerializer
+        def serialize(name, value)
+          "#{CGI.escape(name.to_s)}=#{CGI.escape(value.to_s)}"
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/lib/rswag/specs/query_serializers/specifications/oas3_serializer.rb
+++ b/rswag-specs/lib/rswag/specs/query_serializers/specifications/oas3_serializer.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/hash/conversions'
+require_relative '../collections/multi_serializer'
+require_relative '../collections/xsv_serializer'
+require_relative '../primitive_serializer'
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Specifications
+        # OAS 3: https://swagger.io/docs/specification/serialization/
+        class OAS3Serializer
+          # Maps a style to the corresponding serializer. Uses the CSV separator
+          # by default.
+          COLLECTION_SERIALIZERS = Hash.new(
+            Collections::XSVSerializer.new(','),
+          ).merge(
+            spaceDelimited: Collections::XSVSerializer.new('%20'),
+            pipeDelimited: Collections::XSVSerializer.new('|')
+          ).freeze
+
+          # Holds a multi serializer instance to avoid allocating objects with
+          # each instance / invocation.
+          MULTI_SERIALIZER = Collections::MultiSerializer.new
+
+          # Maps a type to a method that can serialize it. The
+          # `serialize_primitive` method is the default.
+          SERIALIZER_METHOD = Hash.new(
+            :serialize_primitive
+          ).merge(
+            array: :serialize_array,
+            object: :serialize_object
+          ).freeze
+
+          def initialize(param)
+            @name = param[:name]
+            @style = param[:style]&.to_sym
+            @explode = param[:explode].nil? ? true : param[:explode]
+            @type = param[:schema][:type]&.to_sym
+          end
+
+          attr_reader :name, :style, :explode, :type
+
+          def serialize(value)
+            method = SERIALIZER_METHOD[type]
+            send(method, value)
+          end
+
+          def serialize_array(value)
+            return MULTI_SERIALIZER.serialize(name, value.to_a.flatten) if explode
+
+            serializer = COLLECTION_SERIALIZERS[style]
+            serializer.serialize(name, value.to_a.flatten)
+          end
+
+          def serialize_object(value)
+            case style
+            when :deepObject
+              return { name => value }.to_query
+            when :form
+              if explode
+                return value.to_query
+              else
+                serializer = COLLECTION_SERIALIZERS[:form]
+                return serializer.serialize(name, value.to_a.flatten)
+              end
+            end
+          end
+
+          def serialize_primitive(value)
+            PrimitiveSerializer.new.serialize(name, value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/lib/rswag/specs/query_serializers/specifications/swagger_serializer.rb
+++ b/rswag-specs/lib/rswag/specs/query_serializers/specifications/swagger_serializer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative '../collections/multi_serializer'
+require_relative '../collections/xsv_serializer'
+require_relative '../primitive_serializer'
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Specifications
+        class SwaggerSerializer
+          # Maps a collection format to the corresponding serializer. CSV is the
+          # default.
+          COLLECTION_SERIALIZERS = Hash.new(
+            Collections::XSVSerializer.new(',')
+          ).merge(
+            ssv: Collections::XSVSerializer.new(' '),
+            tsv: Collections::XSVSerializer.new('\t'),
+            pipes: Collections::XSVSerializer.new('|'),
+            multi: Collections::MultiSerializer.new
+          ).freeze
+
+          # Maps a type to a method that can serialize it. The
+          # `serialize_primitive` method is the default.
+          SERIALIZER_METHOD = Hash.new(
+            :serialize_primitive
+          ).merge(
+            array: :serialize_array,
+            object: :serialize_object
+          ).freeze
+
+          def initialize(param)
+            @name = param[:name]
+            @type = (param[:type] || param.dig(:schema, :type))&.to_sym
+            @collection_format = param[:collectionFormat]
+          end
+
+          attr_reader :name, :type, :collection_format
+
+          def serialize(value)
+            method = SERIALIZER_METHOD[type]
+            send(method, value)
+          end
+
+          def serialize_array(value)
+            serializer = COLLECTION_SERIALIZERS[collection_format]
+            serializer.serialize(name, value)
+          end
+
+          def serialize_object(value)
+            serialize_primitive(value)
+          end
+
+          def serialize_primitive(value)
+            PrimitiveSerializer.new.serialize(name, value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/spec/rswag/specs/query_serializers/collections/multi_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/collections/multi_serializer_spec.rb
@@ -34,10 +34,10 @@ module Rswag
             end
 
             context "when value contains unescaped characters" do
-              let(:value) { ["something cool", "neato"] }
+              let(:value) { ["something cool", "neat"] }
 
               it "escapes them" do
-                expect(serialize).to eq("values=something+cool&values=neato")
+                expect(serialize).to eq("values=something+cool&values=neat")
               end
             end
           end

--- a/rswag-specs/spec/rswag/specs/query_serializers/collections/multi_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/collections/multi_serializer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rswag/specs/query_serializers/collections/multi_serializer'
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Collections
+        RSpec.describe MultiSerializer do
+          describe "#serialize" do
+            subject(:serialize) { described_class.new.serialize(name, value) }
+
+            let(:name) { "values" }
+            let(:value) { [123, 456] }
+
+            it "serializes the name and value into multiple query parameters" do
+              expect(serialize).to eq("values=123&values=456")
+            end
+
+            context "when value is empty" do
+              let(:value) { [] }
+
+              it "renders a blank string" do
+                expect(serialize).to eq("")
+              end
+            end
+
+            context "when name contains unescaped characters" do
+              let(:name) { "the values" }
+
+              it "escapes them" do
+                expect(serialize).to eq("the+values=123&the+values=456")
+              end
+            end
+
+            context "when value contains unescaped characters" do
+              let(:value) { ["something cool", "neato"] }
+
+              it "escapes them" do
+                expect(serialize).to eq("values=something+cool&values=neato")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/spec/rswag/specs/query_serializers/collections/xsv_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/collections/xsv_serializer_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rswag/specs/query_serializers/collections/xsv_serializer'
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Collections
+        RSpec.describe XSVSerializer do
+          describe "#serialize" do
+            subject(:serialize) { described_class.new(sep).serialize(name, value) }
+
+            let(:sep) { "," }
+            let(:name) { "values" }
+            let(:value) { [123, 456] }
+
+            it "serializes the name and value into a delimited query parameter" do
+              expect(serialize).to eq("values=123,456")
+            end
+
+            context "when value is empty" do
+              let(:value) { [] }
+
+              it "renders a query parameter with a blank value" do
+                expect(serialize).to eq("values=")
+              end
+            end
+
+            context "when name contains unescaped characters" do
+              let(:name) { "the values" }
+
+              it "escapes them" do
+                expect(serialize).to eq("the+values=123,456")
+              end
+            end
+
+            context "when value contains unescaped characters" do
+              let(:value) { ["something cool", "neato"] }
+
+              it "escapes them" do
+                expect(serialize).to eq("values=something+cool,neato")
+              end
+            end
+
+            context "when initialized with a separator" do
+              let(:sep) { "<?>" }
+
+              it "uses the separator to delimit the values" do
+                expect(serialize).to eq("values=123<?>456")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/spec/rswag/specs/query_serializers/collections/xsv_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/collections/xsv_serializer_spec.rb
@@ -35,10 +35,10 @@ module Rswag
             end
 
             context "when value contains unescaped characters" do
-              let(:value) { ["something cool", "neato"] }
+              let(:value) { ["something cool", "neat"] }
 
               it "escapes them" do
-                expect(serialize).to eq("values=something+cool,neato")
+                expect(serialize).to eq("values=something+cool,neat")
               end
             end
 

--- a/rswag-specs/spec/rswag/specs/query_serializers/primitive_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/primitive_serializer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rswag/specs/query_serializers/primitive_serializer'
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      RSpec.describe PrimitiveSerializer do
+        describe "#serialize" do
+          subject(:serialize) { described_class.new.serialize(name, value) }
+
+          let(:name) { "value" }
+          let(:value) { 123_456 }
+
+          it "serializes the name and value into a query parameter" do
+            expect(serialize).to eq("value=123456")
+          end
+
+          context "when name contains unescaped characters" do
+            let(:name) { "the value" }
+
+            it "escapes them" do
+              expect(serialize).to eq("the+value=123456")
+            end
+          end
+
+          context "when value contains unescaped characters" do
+            let(:value) { "something cool" }
+
+            it "escapes them" do
+              expect(serialize).to eq("value=something+cool")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/spec/rswag/specs/query_serializers/specifications/oas3_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/specifications/oas3_serializer_spec.rb
@@ -135,7 +135,7 @@ module Rswag
             context "when style is something invalid" do
               let(:style) { :somethingInvalid }
 
-              # I don't know if this is intentional behaviour or if this is just
+              # I don't know if this is intentional behavior or if this is just
               # a quirk of how serialization was initially implemented.
               it "returns nil" do
                 expect(serialize_object).to be_nil

--- a/rswag-specs/spec/rswag/specs/query_serializers/specifications/oas3_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/specifications/oas3_serializer_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require 'rswag/specs/query_serializers/specifications/oas3_serializer'
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Specifications
+        RSpec.describe OAS3Serializer do
+          describe "#serialize" do
+            subject(:serializer) { described_class.new(param) }
+
+            shared_examples "it serializes" do |method|
+              let(:return_value) { "serialized_value_#{rand(0..1_000)}" }
+
+              before { allow(serializer).to receive(method).and_return(return_value) }
+
+              it "calls the appropriate serializer method" do
+                serializer.serialize(value)
+
+                expect(serializer).to have_received(method).with(value)
+              end
+
+              it "returns the value from the appropriate serializer method" do
+                expect(serializer.serialize(value)).to eq(return_value)
+              end
+            end
+
+            let(:param) { { schema: { type: type } } }
+            let(:type) { [:integer, :date, :string, :float].sample }
+            let(:value) { "raw_value_#{rand(1..1_000)}" }
+
+            it_behaves_like "it serializes", :serialize_primitive
+
+            context "when type is array" do
+              let(:type) { :array }
+
+              it_behaves_like "it serializes", :serialize_array
+            end
+
+            context "when type is object" do
+              let(:type) { :object }
+
+              it_behaves_like "it serializes", :serialize_object
+            end
+          end
+
+          describe "#serialize_array" do
+            subject(:serialize_array) { described_class.new(param).serialize_array(value) }
+
+            shared_examples "it serializes the array" do |serializer|
+              let(:serialized_value) { "anything_#{rand(1..1_000)}" }
+
+              before do
+                allow(serializer).to receive(:serialize).and_return(serialized_value)
+              end
+
+              it "passes the name and value to the serializer" do
+                serialize_array
+                expect(serializer).to have_received(:serialize).with(name, value)
+              end
+
+              it "returns the value from the serializer" do
+                expect(serialize_array).to eq(serialized_value)
+              end
+            end
+
+            let(:param) do
+              {
+                name: name,
+                style: style,
+                explode: explode,
+                schema: { type: :array }
+              }
+            end
+
+            let(:name) { "some_random_name_#{rand(1..1_000)}" }
+            let(:style) { nil }
+            let(:value) { ["raw_value_#{rand(1..1_000)}", "raw_value_#{rand(1..1_000)}"] }
+
+            context "when explode is unspecified" do
+              let(:explode) { nil }
+
+              it_behaves_like "it serializes the array", described_class::MULTI_SERIALIZER
+            end
+
+            context "when explode is true" do
+              let(:explode) { true }
+
+              it_behaves_like "it serializes the array", described_class::MULTI_SERIALIZER
+            end
+
+            context "when explode is false" do
+              let(:explode) { false }
+
+              it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS[:form]
+
+              context "when style is form" do
+                let(:style) { :form }
+
+                it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS[:form]
+              end
+
+              context "when style is spaceDelimited" do
+                let(:style) { :spaceDelimited }
+
+                it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS.fetch(:spaceDelimited)
+              end
+
+              context "when style is pipeDelimited" do
+                let(:style) { :pipeDelimited }
+
+                it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS.fetch(:pipeDelimited)
+              end
+            end
+          end
+
+          describe "#serialize_object" do
+            subject(:serialize_object) { described_class.new(param).serialize_object(value) }
+
+            let(:param) do
+              {
+                name: name,
+                style: style,
+                explode: explode,
+                schema: { type: :array }
+              }
+            end
+
+            let(:name) { "some_random_name_#{rand(1..1_000)}" }
+            let(:style) { nil }
+            let(:explode) { nil }
+            let(:value) { { one: "raw_value_#{rand(1..1_000)}", two: "raw_value_#{rand(1..1_000)}" } }
+
+            context "when style is something invalid" do
+              let(:style) { :somethingInvalid }
+
+              # I don't know if this is intentional behaviour or if this is just
+              # a quirk of how serialization was initially implemented.
+              it "returns nil" do
+                expect(serialize_object).to be_nil
+              end
+            end
+
+            context "when style is deepObject" do
+              let(:style) { :deepObject }
+
+              it "uses ActiveSupport's #to_query method on the name and value" do
+                expect(serialize_object).to eq({ name => value }.to_query)
+              end
+            end
+
+            context "when style is form" do
+              let(:style) { :form }
+
+              context "when explode is true" do
+                let(:explode) { true }
+
+                it "uses ActiveSupport's #to_query method on the value" do
+                  expect(serialize_object).to eq(value.to_query)
+                end
+              end
+
+              context "when explode is false" do
+                let(:explode) { false }
+                let(:serializer) { described_class::COLLECTION_SERIALIZERS[:form] }
+                let(:serialized_value) { "something_random_#{rand(1..1_000)}" }
+
+                before do
+                  allow(serializer).to receive(:serialize).and_return(serialized_value)
+                end
+
+                it "serializes the flattened parameter with the form serializer" do
+                  serialize_object
+                  expect(serializer).to have_received(:serialize).with(name, value.to_a.flatten)
+                end
+
+                it "returns the value from the form serializer" do
+                  expect(serialize_object).to eq(serialized_value)
+                end
+              end
+            end
+          end
+
+          describe "#serialize_primitive" do
+            subject(:serialize_primitive) { described_class.new(param).serialize_primitive(value) }
+
+            let(:param) { { name: name, schema: { type: :string } } }
+            let(:name) { "some_random_name_#{rand(1..1_000)}" }
+            let(:value) { "raw_value_#{rand(1..1_000)}" }
+
+            let(:primitive_double) { instance_double(PrimitiveSerializer) }
+            let(:serialized_value) { "anything_#{rand(1..1_000)}" }
+
+            before do
+              allow(PrimitiveSerializer).to receive(:new).and_return(primitive_double)
+              allow(primitive_double).to receive(:serialize).and_return(serialized_value)
+            end
+
+            it "passes the name and value to the primitive serializer" do
+              serialize_primitive
+              expect(primitive_double).to have_received(:serialize).with(name, value)
+            end
+
+            it "returns the value from the primitive serializer" do
+              expect(serialize_primitive).to eq(serialized_value)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/rswag-specs/spec/rswag/specs/query_serializers/specifications/swagger_serializer_spec.rb
+++ b/rswag-specs/spec/rswag/specs/query_serializers/specifications/swagger_serializer_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rswag/specs/query_serializers/specifications/swagger_serializer'
+
+module Rswag
+  module Specs
+    module QuerySerializers
+      module Specifications
+        RSpec.describe SwaggerSerializer do
+          describe "#serialize" do
+            subject(:serializer) { described_class.new(param) }
+
+            shared_examples "it serializes" do |method|
+              let(:return_value) { "serialized_value_#{rand(0..1_000)}" }
+
+              before { allow(serializer).to receive(method).and_return(return_value) }
+
+              it "calls the appropriate serializer method" do
+                serializer.serialize(value)
+
+                expect(serializer).to have_received(method).with(value)
+              end
+
+              it "returns the value from the appropriate serializer method" do
+                expect(serializer.serialize(value)).to eq(return_value)
+              end
+            end
+
+            let(:param) { { type: type } }
+            let(:type) { [:integer, :date, :string, :float].sample }
+            let(:value) { "raw_value_#{rand(1..1_000)}" }
+
+            it_behaves_like "it serializes", :serialize_primitive
+
+            context "when type is array" do
+              let(:type) { :array }
+
+              it_behaves_like "it serializes", :serialize_array
+            end
+
+            context "when type is object" do
+              let(:type) { :object }
+
+              it_behaves_like "it serializes", :serialize_object
+            end
+          end
+
+          describe "#serialize_array" do
+            subject(:serialize_array) { described_class.new(param).serialize_array(value) }
+
+            shared_examples "it serializes the array" do |serializer|
+              let(:serialized_value) { "anything_#{rand(1..1_000)}" }
+
+              before do
+                allow(serializer).to receive(:serialize).and_return(serialized_value)
+              end
+
+              it "passes the name and value to the serializer" do
+                serialize_array
+                expect(serializer).to have_received(:serialize).with(name, value)
+              end
+
+              it "returns the value from the serializer" do
+                expect(serialize_array).to eq(serialized_value)
+              end
+            end
+
+            let(:param) { { name: name, collectionFormat: collection_format } }
+            let(:name) { "some_random_name_#{rand(1..1_000)}" }
+            let(:collection_format) { nil }
+            let(:value) { "raw_value_#{rand(1..1_000)}" }
+
+            it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS[:csv]
+
+            context "when collectionFormat is csv" do
+              let(:collection_format) { :csv }
+
+              it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS[:csv]
+            end
+
+            context "when collectionFormat is ssv" do
+              let(:collection_format) { :ssv }
+
+              it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS.fetch(:ssv)
+            end
+
+            context "when collectionFormat is tsv" do
+              let(:collection_format) { :tsv }
+
+              it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS.fetch(:tsv)
+            end
+
+            context "when collectionFormat is pipes" do
+              let(:collection_format) { :pipes }
+
+              it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS.fetch(:pipes)
+            end
+
+            context "when collectionFormat is multi" do
+              let(:collection_format) { :multi }
+
+              it_behaves_like "it serializes the array", described_class::COLLECTION_SERIALIZERS.fetch(:multi)
+            end
+          end
+
+          describe "#serialize_object" do
+            subject(:serialize_object) { described_class.new(param).serialize_object(value) }
+
+            let(:param) { { name: name } }
+            let(:name) { "some_random_name_#{rand(1..1_000)}" }
+            let(:value) { "raw_value_#{rand(1..1_000)}" }
+
+            let(:primitive_double) { instance_double(PrimitiveSerializer) }
+            let(:serialized_value) { "anything_#{rand(1..1_000)}" }
+
+            before do
+              allow(PrimitiveSerializer).to receive(:new).and_return(primitive_double)
+              allow(primitive_double).to receive(:serialize).and_return(serialized_value)
+            end
+
+            it "passes the name and value to the primitive serializer" do
+              serialize_object
+              expect(primitive_double).to have_received(:serialize).with(name, value)
+            end
+
+            it "returns the value from the primitive serializer" do
+              expect(serialize_object).to eq(serialized_value)
+            end
+          end
+
+          describe "#serialize_primitive" do
+            subject(:serialize_primitive) { described_class.new(param).serialize_primitive(value) }
+
+            let(:param) { { name: name } }
+            let(:name) { "some_random_name_#{rand(1..1_000)}" }
+            let(:value) { "raw_value_#{rand(1..1_000)}" }
+
+            let(:primitive_double) { instance_double(PrimitiveSerializer) }
+            let(:serialized_value) { "anything_#{rand(1..1_000)}" }
+
+            before do
+              allow(PrimitiveSerializer).to receive(:new).and_return(primitive_double)
+              allow(primitive_double).to receive(:serialize).and_return(serialized_value)
+            end
+
+            it "passes the name and value to the primitive serializer" do
+              serialize_primitive
+              expect(primitive_double).to have_received(:serialize).with(name, value)
+            end
+
+            it "returns the value from the primitive serializer" do
+              expect(serialize_primitive).to eq(serialized_value)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The query parameter serialization logic in the `RequestFactory` class is complicated and difficult to test well. In addition, it does not consistently escape query parameter names and values (depends on whether you're using OAS 2 vs OAS 3).

## Solution

Split out the parameter serialization logic into classes where logic can be reused and more easily unit tested.

### Notes

This change was made with the intention of being 100% compatible with the previous implementation. The only exception is that OAS 2 query parameters are now escaped with `CGI.escape` when previously they were not.

If the change is an issue, I can tweak my changes to preserve the previous escaping behaviour.

### File Structure

I added a new `query_serializers` folder with the following structure:

```
rswag-specs/lib/rswag/specs/query_serializers
├── collections
│   ├── multi_serializer.rb
│   └── xsv_serializer.rb
├── primitive_serializer.rb
└── specifications
    ├── oas3_serializer.rb
    └── swagger_serializer.rb
```

* The `collections` folder contains serializers that work on arrays.
* The `specifications` folder contains serializers that adhere to specifications like OAS 2 or OAS 3

I'm definitely open to changing class names and/or moving files around!

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

#621 fixed query parameter encoding for OAS 3, but that was never back-ported to OAS 2 serialization.

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] ~Added documentation to README.md~ N/A
- [ ] ~Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)~ N/A

### Steps to Test

The existing specs were left to show that I didn't break compatibility with the original implementation. I added unit tests for each added class to ensure 100% coverage.

### Motivation

While I truly believe this code is more maintainable, I didn't make this change without selfish motivations. 😄 

I currently have a fork of this gem where I have made changes to support a custom query parameter format. By splitting the logic out into classes, I can change my application to monkey patch specific classes to support my custom format without needing to maintain a fork.