### PR TITLE
fix: remove invalid fields when generating oas 3 docs

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -80,10 +80,13 @@ module Rswag
 
                   value[:parameters].reject! { |p| p[:in] == :body || p[:in] == :formData }
                 end
-                remove_invalid_operation_keys!(value)
+                remove_invalid_path_operation_keys!(value)
               end
             end
+
+            remove_invalid_root_keys!(doc)
           end
+
 
           file_path = File.join(@config.swagger_root, url_path)
           dirname = File.dirname(file_path)
@@ -207,7 +210,14 @@ module Rswag
         end
       end
 
-      def remove_invalid_operation_keys!(value)
+      # only have valid oas v3 fields
+      # based on https://spec.openapis.org/oas/v3.1.0#fixed-fields
+      def remove_invalid_root_keys!(doc)
+        new_doc = doc.slice(:openapi, :info, :jsonSchemaDialect, :servers, :paths, :webhooks, :components, :security, :tags, :externalDocs)
+        doc.replace(new_doc)
+      end
+
+      def remove_invalid_path_operation_keys!(value)
         return unless value.is_a?(Hash)
 
         value.delete(:consumes) if value[:consumes]

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -482,6 +482,38 @@ module Rswag
           end
         end
 
+        context 'with invalid oas 3 root fields' do
+          let(:doc_2) do
+            {
+              openapi: '3.0.1',
+              paths: {
+                '/path/' => {
+                  post: {
+                    parameters: [{
+                      in: :body,
+                      description: "description",
+                      schema: { type: :number }
+                    }]
+                  }
+                }
+              },
+              consumes: ['application/json']
+            }
+          end
+
+          it 'removes invalid field' do
+            expect(doc_2[:consumes]).to be_nil
+          end
+
+          it 'removes invalid field' do
+            expect(doc_2[:paths]['/path/'][:post][:requestBody][:content]).to eql({
+              'application/json' => {
+                schema: { type: :number }
+              }
+            })
+          end
+        end
+
         after do
           FileUtils.rm_r(swagger_root) if File.exist?(swagger_root)
         end

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -501,11 +501,11 @@ module Rswag
             }
           end
 
-          it 'removes invalid field' do
+          it 'removes invalid fields' do
             expect(doc_2[:consumes]).to be_nil
           end
 
-          it 'removes invalid field' do
+          it 'consume in root still applies' do
             expect(doc_2[:paths]['/path/'][:post][:requestBody][:content]).to eql({
               'application/json' => {
                 schema: { type: :number }


### PR DESCRIPTION
## Problem
Rswag::Specs::SwaggerFormatter supports default content type when you defined consumes or produces in swagger_doc but this only works for OAS 2 as it adds field that are incompatible with OAS 3

## Solution
Remove invalid root fields when generating for OAS 3 

### This concerns this parts of the OpenAPI Specification:
I remove fields that do not belong in https://spec.openapis.org/oas/v3.1.0#fixed-fields

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Add `produces:` or any key in the swagger_docs config, will remove any invalid fields if openapi is version 3


