### PR TITLE
Allowing response metadata to also be passed in in the symbol metadata style.

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -67,6 +67,9 @@ module Rswag
       end
 
       def response(code, description, metadata = {}, &block)
+        if metadata.is_a?(Symbol)
+          metadata = { metadata => true }
+        end
         metadata[:response] = { code: code, description: description }
         context(description, metadata, &block)
       end

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -66,9 +66,14 @@ module Rswag
         end
       end
 
-      def response(code, description, metadata = {}, &block)
-        if metadata.is_a?(Symbol)
-          metadata = { metadata => true }
+      def response(code, description, *metadata, &block)
+        metadata = metadata.reduce({}) do |acc, item|
+          if item.is_a?(Symbol)
+            acc[item] = true
+          elsif item.is_a?(Hash)
+            acc.merge!(item)
+          end
+          acc
         end
         metadata[:response] = { code: code, description: description }
         context(description, metadata, &block)

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -127,6 +127,28 @@ module Rswag
           )
         end
       end
+      describe '#response(code, description, metadata)' do
+
+        describe "when metadata is a hash" do
+          before { subject.response('201', 'success', foo: 'bar') }
+
+          it "delegates to 'context' with 'response' metadata and provided metadata" do
+            expect(subject).to have_received(:context).with(
+              'success', response: { code: '201', description: 'success' }, foo: 'bar'
+            )
+          end
+        end
+
+        describe "when metadata is a symbol" do
+          before { subject.response('201', 'success', :foo) }
+
+          it "delegates to 'context' with 'response' metadata and provided metadata" do
+            expect(subject).to have_received(:context).with(
+              'success', response: { code: '201', description: 'success' }, foo: true
+            )
+          end
+        end
+      end
 
       describe '#schema(value)' do
         before { subject.schema(type: 'object') }

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -25,6 +25,38 @@ module Rswag
         end
       end
 
+      describe "#path(path, metadata)" do
+        describe "when metadata is a hash" do
+          before { subject.path('/blogs', foo: 'bar') }
+
+          it "delegates to 'describe' with 'response' metadata" do
+            expect(subject).to have_received(:describe).with(
+              '/blogs', path_item: { template: '/blogs' }, foo: 'bar'
+            )
+          end
+        end
+
+        describe "when metadata is a symbol" do
+          before { subject.path('/blogs', :foo) }
+
+          it "delegates to 'describe' with 'response' metadata" do
+            expect(subject).to have_received(:describe).with(
+              '/blogs', path_item: { template: '/blogs' }, foo: true
+            )
+          end
+        end
+
+        describe "when metadata is a mix of symbols and hashes" do
+          before { subject.path('/blogs', :foo, :qux, bar: 'baz') }
+
+          it "delegates to 'describe' with 'response' metadata" do
+            expect(subject).to have_received(:describe).with(
+              '/blogs', path_item: { template: '/blogs' }, foo: true, bar: 'baz', qux: true
+            )
+          end
+        end
+      end
+
       describe '#get|post|patch|put|delete|head|options|trace(verb, summary)' do
         context 'when called without keyword arguments' do
           before { subject.post('Creates a blog') }
@@ -42,6 +74,16 @@ module Rswag
           it "delegates to 'describe' with 'operation' metadata and provided metadata" do
             expect(subject).to have_received(:describe).with(
               :post, operation: { verb: :post, summary: 'Creates a blog' }, foo: 'bar'
+            )
+          end
+        end
+
+        context 'when called with symbol and hash arguments' do
+          before { subject.post('Creates a blog', :foo, bar: 'baz') }
+
+          it "delegates to 'describe' with 'operation' metadata and provided metadata" do
+            expect(subject).to have_received(:describe).with(
+              :post, operation: { verb: :post, summary: 'Creates a blog' }, foo: true, bar: 'baz'
             )
           end
         end
@@ -149,7 +191,7 @@ module Rswag
           end
         end
 
-        describe "when metadata is a mix of symbols and hashs" do
+        describe "when metadata is a mix of symbols and hashes" do
           before { subject.response('201', 'success', :foo, :qux, bar: 'baz') }
 
           it "delegates to 'context' with 'response' metadata and provided metadata" do

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -148,6 +148,16 @@ module Rswag
             )
           end
         end
+
+        describe "when metadata is a mix of symbols and hashs" do
+          before { subject.response('201', 'success', :foo, :qux, bar: 'baz') }
+
+          it "delegates to 'context' with 'response' metadata and provided metadata" do
+            expect(subject).to have_received(:context).with(
+              'success', response: { code: '201', description: 'success' }, foo: true, bar: 'baz', qux: true
+            )
+          end
+        end
       end
 
       describe '#schema(value)' do


### PR DESCRIPTION
## Problem

https://github.com/rswag/rswag/issues/674

In keeping with metadata styling, as per rubocop's [rspec metadata style](https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmetadatastyle). We should be able to pass

## Solution
Handle the case of metadata being passed as a symbol.

### The changes I made are compatible with:
- [X] OAS2
- [X] OAS3
- [X] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
