### PR TITLE
chore: add more information about generating docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Documentation
 
+- Added more details about config swagger format [#698](https://github.com/rswag/rswag/pull/698)
+
 ## [2.13.0]
 
 ### Added
@@ -38,7 +40,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Add warning about methods renaming (https://github.com/rswag/rswag/pull/688)
-- Added more details about config swagger format [#698](https://github.com/rswag/rswag/pull/698)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Add warning about methods renaming (https://github.com/rswag/rswag/pull/688)
+- Added more details about config swagger format [#698](https://github.com/rswag/rswag/pull/698)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -456,6 +456,9 @@ By default, the swagger docs are generated in JSON format. If you want to genera
 RSpec.configure do |config|
   config.openapi_root = Rails.root.to_s + '/swagger'
   
+  # Use if you want to see which test is running
+  # config.formatter = :documentation
+
   # Generate swagger docs in YAML format
   config.openapi_format = :yaml
 

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ RSpec.configure do |config|
       ]
     },
 
-    'v2/swagger.yaml' => {
+    'v2/swagger.json' => {
       openapi: '3.0.1',
       info: {
         title: 'API V2',
@@ -437,13 +437,48 @@ By default, the paths, operations and responses defined in your spec files will 
 
 ```ruby
 # spec/requests/v2/blogs_spec.rb
-describe 'Blogs API', swagger_doc: 'v2/swagger.yaml' do
+describe 'Blogs API', swagger_doc: 'v2/swagger.json' do
 
   path '/blogs' do
   ...
 
   path '/blogs/{id}' do
   ...
+end
+```
+
+#### Supporting YAML format ####
+
+By default, the swagger docs are generated in JSON format. If you want to generate them in YAML format, you can specify the swagger format in the swagger_helper.rb file:
+
+```ruby
+# spec/swagger_helper.rb
+RSpec.configure do |config|
+  config.swagger_root = Rails.root.to_s + '/swagger'
+  
+  # Generate swagger docs in YAML format
+  config.swagger_format = :yaml
+
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1',
+        description: 'This is the first version of my API'
+      },
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+                default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    },
+  }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -454,12 +454,12 @@ By default, the swagger docs are generated in JSON format. If you want to genera
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.swagger_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.to_s + '/swagger'
   
   # Generate swagger docs in YAML format
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 
-  config.swagger_docs = {
+  config.openapi_specs = {
     'v1/swagger.yaml' => {
       openapi: '3.0.1',
       info: {


### PR DESCRIPTION
## Problem
It's a missunderstanding of config

## Solution
improvements of docs

### This concerns this parts of the OpenAPI Specification:


### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/697

### Checklist
- [ ] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Not needed
