### PR TITLE
Fix deprecation warnings in version 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Add deprecation warnings for `Rswag::Api` configuration (https://github.com/rswag/rswag/pull/702)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Fix deprecation warnings for `Rswag::Specs` configuration (https://github.com/rswag/rswag/pull/702)
+
 ### Documentation
 
 ## [2.12.0]

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'climate_control'
   gem 'geckodriver-helper'
   gem 'generator_spec'
   gem 'rspec-rails'

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ By default, if response body contains undocumented properties tests will pass. T
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.swagger_strict_schema_validation = true
+  config.openapi_strict_schema_validation = true
 end
 ```
 
@@ -278,7 +278,7 @@ describe 'Blogs API' do
       response '201', 'blog created' do
         let(:blog) { { title: 'foo', content: 'bar' } }
 
-        run_test!(swagger_strict_schema_validation: true)
+        run_test!(openapi_strict_schema_validation: true)
       end
     end
   end
@@ -290,7 +290,7 @@ describe 'Blogs API' do
     post 'Creates a blog' do
       ...
 
-      response '201', 'blog created', swagger_strict_schema_validation: true do
+      response '201', 'blog created', openapi_strict_schema_validation: true do
         let(:blog) { { title: 'foo', content: 'bar' } }
 
         run_test!
@@ -311,7 +311,7 @@ describe 'Blogs API' do
           submit_request(example.metadata)
         end
 
-        it 'returns a valid 201 response', swagger_strict_schema_validation: true do |example|
+        it 'returns a valid 201 response', openapi_strict_schema_validation: true do |example|
           assert_response_matches_metadata(example.metadata)
         end
       end
@@ -385,9 +385,9 @@ In addition to paths, operations and responses, Swagger also supports global API
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.swagger_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.to_s + '/swagger'
 
-  config.swagger_docs = {
+  config.openapi_specs = {
     'v1/swagger.json' => {
       openapi: '3.0.1',
       info: {
@@ -433,11 +433,11 @@ end
 ```
 
 #### Supporting multiple versions of API ####
-By default, the paths, operations and responses defined in your spec files will be associated with the first Swagger document in _swagger_helper.rb_. If your API has multiple versions, you should be using separate documents to describe each of them. In order to assign a file with a given version of API, you'll need to add the ```swagger_doc``` tag to each spec specifying its target document name:
+By default, the paths, operations and responses defined in your spec files will be associated with the first Swagger document in _swagger_helper.rb_. If your API has multiple versions, you should be using separate documents to describe each of them. In order to assign a file with a given version of API, you'll need to add the ```openapi_spec``` tag to each spec specifying its target document name:
 
 ```ruby
 # spec/requests/v2/blogs_spec.rb
-describe 'Blogs API', swagger_doc: 'v2/swagger.yaml' do
+describe 'Blogs API', openapi_spec: 'v2/swagger.yaml' do
 
   path '/blogs' do
   ...
@@ -475,9 +475,9 @@ Swagger supports :basic, :bearer, :apiKey and :oauth2 and :openIdConnect scheme 
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.swagger_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.to_s + '/swagger'
 
-  config.swagger_docs = {
+  config.openapi_specs = {
     'v1/swagger.json' => {
       ...  # note the new Open API 3.0 compliant security structure here, under "components"
       components: {
@@ -566,7 +566,7 @@ You can adjust this in the _swagger_helper.rb_ that's installed with __rswag-spe
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.swagger_root = Rails.root.to_s + '/your-custom-folder-name'
+  config.openapi_root = Rails.root.to_s + '/your-custom-folder-name'
   ...
 end
 ```
@@ -600,7 +600,7 @@ Rather than repeating the schema in every operation spec, you can define it glob
 
 ```ruby
 # spec/swagger_helper.rb
-config.swagger_docs = {
+config.openapi_specs = {
   'v1/swagger.json' => {
     openapi: '3.0.0',
     info: {
@@ -796,12 +796,12 @@ end
 #### Dry Run Option ####
 
 The `--dry-run` option is enabled by default for Rspec 3, but if you need to
-disable it you can use the environment variable `SWAGGER_DRY_RUN=0` during the
+disable it you can use the environment variable `RSWAG_DRY_RUN=0` during the
 generation command or add the following to your `config/environments/test.rb`:
 
 ```ruby
 RSpec.configure do |config|
-  config.swagger_dry_run = false
+  config.rswag_dry_run = false
 end
 ```
 
@@ -837,7 +837,7 @@ describe 'Blogs API', document: false do
 <!--
 There are some helper methods to help with documenting request bodies.
 ```ruby
-describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
+describe 'Blogs API', type: :request, openapi_spec: 'v1/swagger.json' do
   let(:api_key) { 'fake_key' }
 
   path '/blogs' do
@@ -975,7 +975,7 @@ TestApp::Application.routes.draw do
 end
 ```
 
-Assuming a Swagger file exists at &lt;swagger_root&gt;/v1/swagger.json, this configuration would expose the file as the following JSON endpoint:
+Assuming a Swagger file exists at &lt;openapi_root&gt;/v1/swagger.json, this configuration would expose the file as the following JSON endpoint:
 
 ```
 GET http://<hostname>/your-custom-prefix/v1/swagger.json
@@ -992,7 +992,7 @@ Rswag::Api.configure do |c|
 end
 ```
 
-__NOTE__: If you're using rswag-specs to generate Swagger files, you'll want to ensure they both use the same &lt;swagger_root&gt;. The reason for separate settings is to maintain independence between the two gems. For example, you could install rswag-api independently and create your Swagger files manually.
+__NOTE__: If you're using rswag-specs to generate Swagger files, you'll want to ensure they both use the same &lt;openapi_root&gt;. The reason for separate settings is to maintain independence between the two gems. For example, you could install rswag-api independently and create your Swagger files manually.
 
 ### Dynamic Values for Swagger JSON ##
 
@@ -1029,8 +1029,8 @@ You can update the _rswag_ui.rb_ initializer, installed with rswag-ui, to specif
 
 ```ruby
 Rswag::Ui.configure do |c|
-  c.swagger_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
-  c.swagger_endpoint '/api-docs/v2/swagger.json', 'API V2 Docs'
+  c.openapi_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
+  c.openapi_endpoint '/api-docs/v2/swagger.json', 'API V2 Docs'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ You can adjust this in the _rswag_api.rb_ initializer that's installed with __rs
 
 ```ruby
 Rswag::Api.configure do |c|
-  c.swagger_root = Rails.root.to_s + '/your-custom-folder-name'
+  c.openapi_root = Rails.root.to_s + '/your-custom-folder-name'
   ...
 end
 ```

--- a/rswag-api/lib/generators/rswag/api/install/templates/rswag_api.rb
+++ b/rswag-api/lib/generators/rswag/api/install/templates/rswag_api.rb
@@ -4,7 +4,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.to_s + '/swagger'
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/rswag-api/lib/rswag/api.rb
+++ b/rswag-api/lib/rswag/api.rb
@@ -1,8 +1,14 @@
+require 'active_support/deprecation'
 require 'rswag/api/configuration'
-require 'rswag/api/engine'
+require 'rswag/api/engine' if defined?(Rails::Engine)
 
 module Rswag
   module Api
+    RENAMED_METHODS = {
+      swagger_root: :openapi_root
+    }.freeze
+    private_constant :RENAMED_METHODS
+
     def self.configure
       yield(config)
     end
@@ -10,5 +16,22 @@ module Rswag
     def self.config
       @config ||= Configuration.new
     end
+
+    def self.deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new('3.0', 'rswag-api')
+    end
+
+    Configuration.class_eval do
+      RENAMED_METHODS.each do |old_name, new_name|
+        define_method("#{old_name}=") do |*args, &block|
+          public_send("#{new_name}=", *args, &block)
+        end
+      end
+    end
+
+    Api.deprecator.deprecate_methods(
+      Configuration,
+      RENAMED_METHODS.to_h { |old_name, new_name| ["#{old_name}=".to_sym, "#{new_name}=".to_sym] }
+    )
   end
 end

--- a/rswag-api/lib/rswag/api/configuration.rb
+++ b/rswag-api/lib/rswag/api/configuration.rb
@@ -1,11 +1,19 @@
 module Rswag
   module Api
     class Configuration
-      attr_accessor :swagger_root, :swagger_filter, :swagger_headers
+      attr_accessor :openapi_root, :swagger_filter, :swagger_headers
 
-      def resolve_swagger_root(env)
+      def resolve_openapi_root(env)
         path_params = env['action_dispatch.request.path_parameters'] || {}
-        path_params[:swagger_root] || swagger_root
+
+        if path_params.key?(:swagger_root)
+          Rswag::Api.deprecator.warn(
+            'swagger_root is deprecated and will be removed from rswag-api 3.0 (use openapi_root instead)'
+          )
+          return path_params[:swagger_root]
+        end
+
+        path_params[:openapi_root] || openapi_root
       end
     end
   end

--- a/rswag-api/lib/rswag/api/middleware.rb
+++ b/rswag-api/lib/rswag/api/middleware.rb
@@ -5,7 +5,6 @@ require 'rack/mime'
 module Rswag
   module Api
     class Middleware
-
       def initialize(app, config)
         @app = app
         @config = config
@@ -15,10 +14,9 @@ module Rswag
         path = env['PATH_INFO']
         # Sanitize the filename for directory traversal by expanding, and ensuring
         # its starts with the root directory.
-        filename = File.expand_path(File.join(@config.resolve_swagger_root(env), path))
-        unless filename.start_with? @config.resolve_swagger_root(env).to_s
-          return @app.call(env)
-        end
+        openapi_root = @config.resolve_openapi_root(env)
+        filename = File.expand_path(File.join(openapi_root, path))
+        return @app.call(env) unless filename.start_with? openapi_root.to_s
 
         if env['REQUEST_METHOD'] == 'GET' && File.file?(filename)
           swagger = parse_file(filename)
@@ -30,11 +28,11 @@ module Rswag
           return [
             '200',
             headers,
-            [ body ]
+            [body]
           ]
         end
 
-        return @app.call(env)
+        @app.call(env)
       end
 
       private

--- a/rswag-api/rswag-api.gemspec
+++ b/rswag-api/rswag-api.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']
 
+  s.add_dependency 'activesupport', '>= 3.1', '< 7.2'
   s.add_dependency 'railties', '>= 3.1', '< 7.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'

--- a/rswag-api/spec/lib/rswag/api/configuration_spec.rb
+++ b/rswag-api/spec/lib/rswag/api/configuration_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rswag::Api::Configuration do
+  subject(:configuration) { described_class.new }
+
+  describe '#swagger_root=' do
+    it 'is deprecated' do
+      allow(Rswag::Api.deprecator).to receive(:warn)
+      configuration.swagger_root = 'foobar'
+      expect(subject.openapi_root).to eq('foobar')
+      expect(Rswag::Api.deprecator).to(
+        have_received(:warn)
+          .with('swagger_root= is deprecated and will be removed from rswag-api 3.0 (use openapi_root= instead)',
+                any_args)
+      )
+    end
+  end
+end

--- a/rswag-api/spec/lib/rswag/api_spec.rb
+++ b/rswag-api/spec/lib/rswag/api_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe Rswag::Api do
+  describe '::configure' do
+    it 'yields a configuration object' do
+      expect { |b| described_class.configure(&b) }.to yield_with_args(instance_of(Rswag::Api::Configuration))
+    end
+  end
+end

--- a/rswag-api/spec/rswag/api/middleware_spec.rb
+++ b/rswag-api/spec/rswag/api/middleware_spec.rb
@@ -1,154 +1,179 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
 require 'rswag/api/middleware'
 require 'rswag/api/configuration'
 
-module Rswag
-  module Api
+describe Rswag::Api::Middleware do
+  let(:app) { double('app') }
+  let(:openapi_root) { File.expand_path('fixtures/swagger', __dir__) }
+  let(:config) do
+    Rswag::Api::Configuration.new.tap { |c| c.openapi_root = openapi_root }
+  end
 
-    describe Middleware do
-      let(:app) { double('app') }
-      let(:swagger_root) { File.expand_path('../fixtures/swagger', __FILE__) }
-      let(:config) do
-        Configuration.new.tap { |c| c.swagger_root = swagger_root }
+  subject { described_class.new(app, config) }
+
+  describe '#call(env)' do
+    let(:response) { subject.call(env) }
+    let(:env_defaults) do
+      {
+        'HTTP_HOST' => 'tempuri.org',
+        'REQUEST_METHOD' => 'GET'
+      }
+    end
+
+    context 'given a path that maps to an existing swagger file' do
+      let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.json') }
+
+      it 'returns a 200 status' do
+        expect(response.length).to eql(3)
+        expect(response.first).to eql('200')
       end
 
-      subject { described_class.new(app, config) }
+      it 'returns contents of the swagger file' do
+        expect(response.length).to eql(3)
+        expect(response[1]).to include('Content-Type' => 'application/json')
+        expect(response[2].join).to include('"title":"API V1"')
+      end
 
-      describe '#call(env)' do
-        let(:response) { subject.call(env) }
-        let(:env_defaults) do
-          {
-            'HTTP_HOST' => 'tempuri.org',
-            'REQUEST_METHOD' => 'GET',
+      context 'configured with a Pathname similar to `Rails.root.join("swagger")`' do
+        let(:openapi_root_pathname) { Pathname.new(openapi_root) }
+
+        before { config.openapi_root = openapi_root_pathname }
+
+        it 'returns a 200 status' do
+          expect(response.length).to eql(3)
+          expect(response.first).to eql('200')
+        end
+      end
+    end
+
+    context 'when swagger_headers is configured' do
+      let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.json') }
+
+      context 'replacing the default content type header' do
+        before do
+          config.swagger_headers = { 'Content-Type' => 'application/json; charset=UTF-8' }
+        end
+        it 'returns a 200 status' do
+          expect(response.length).to eql(3)
+          expect(response.first).to eql('200')
+        end
+
+        it 'applies the headers to the response' do
+          expect(response[1]).to include('Content-Type' => 'application/json; charset=UTF-8')
+        end
+      end
+
+      context 'adding an additional header' do
+        before do
+          config.swagger_headers = { 'Access-Control-Allow-Origin' => '*' }
+        end
+        it 'returns a 200 status' do
+          expect(response.length).to eql(3)
+          expect(response.first).to eql('200')
+        end
+
+        it 'applies the headers to the response' do
+          expect(response[1]).to include('Access-Control-Allow-Origin' => '*')
+        end
+
+        it 'keeps the default header' do
+          expect(response[1]).to include('Content-Type' => 'application/json')
+        end
+      end
+    end
+
+    context "given a path that doesn't map to any swagger file" do
+      let(:env) { env_defaults.merge('PATH_INFO' => 'foobar.json') }
+      before do
+        allow(app).to receive(:call).and_return(['500', {}, []])
+      end
+
+      it 'delegates to the next middleware' do
+        expect(response).to include('500')
+      end
+    end
+
+    context 'Disallow path traversing on path info' do
+      let(:env) { env_defaults.merge('PATH_INFO' => '../traverse-secret.yml') }
+      before do
+        allow(app).to receive(:call).and_return(['500', {}, []])
+      end
+
+      it 'delegates to the next middleware' do
+        expect(response).to include('500')
+      end
+    end
+
+    context 'when the env contains a specific swagger_root' do
+      let(:env) do
+        env_defaults.merge(
+          'PATH_INFO' => 'v1/swagger.json',
+          'action_dispatch.request.path_parameters' => {
+            swagger_root: openapi_root
           }
-        end
+        )
+      end
 
-        context 'given a path that maps to an existing swagger file' do
-          let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.json') }
+      before do
+        allow(Rswag::Api.deprecator).to receive(:warn)
+      end
 
-          it 'returns a 200 status' do
-            expect(response.length).to eql(3)
-            expect(response.first).to eql('200')
-          end
+      it 'locates files at the provided swagger_root' do
+        expect(response.length).to eql(3)
+        expect(response[1]).to include('Content-Type' => 'application/json')
+        expect(response[2].join).to include('"openapi":"3.0.1"')
+        expect(Rswag::Api.deprecator).to(
+          have_received(:warn)
+            .with('swagger_root is deprecated and will be removed from rswag-api 3.0 (use openapi_root instead)')
+        )
+      end
+    end
 
-          it 'returns contents of the swagger file' do
-            expect(response.length).to eql(3)
-            expect(response[1]).to include( 'Content-Type' => 'application/json')
-            expect(response[2].join).to include('"title":"API V1"')
-          end
+    context 'when the env contains a specific openapi_root' do
+      let(:env) do
+        env_defaults.merge(
+          'PATH_INFO' => 'v1/swagger.json',
+          'action_dispatch.request.path_parameters' => {
+            openapi_root: openapi_root
+          }
+        )
+      end
 
-          context 'configured with a Pathname similar to `Rails.root.join("swagger")`' do
-            let(:swagger_root_pathname) { Pathname.new(swagger_root) }
+      it 'locates files at the provided openapi_root' do
+        expect(response.length).to eql(3)
+        expect(response[1]).to include('Content-Type' => 'application/json')
+        expect(response[2].join).to include('"openapi":"3.0.1"')
+      end
+    end
 
-            before { config.swagger_root = swagger_root_pathname }
 
-            it 'returns a 200 status' do
-              expect(response.length).to eql(3)
-              expect(response.first).to eql('200')
-            end
-          end
-        end
+    context 'when a swagger_filter is configured' do
+      before do
+        config.swagger_filter = ->(swagger, env) { swagger['host'] = env['HTTP_HOST'] }
+      end
+      let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.json') }
 
-        context 'when swagger_headers is configured' do
-          let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.json') }
+      it 'applies the filter prior to serialization' do
+        expect(response.length).to eql(3)
+        expect(response[2].join).to include('"host":"tempuri.org"')
+      end
+    end
 
-          context 'replacing the default content type header' do
-            before do
-              config.swagger_headers = { 'Content-Type' => 'application/json; charset=UTF-8' }
-            end
-            it 'returns a 200 status' do
-              expect(response.length).to eql(3)
-              expect(response.first).to eql('200')
-            end
+    context 'when a path maps to a yaml swagger file' do
+      let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.yml') }
 
-            it 'applies the headers to the response' do
-              expect(response[1]).to include( 'Content-Type' => 'application/json; charset=UTF-8')
-            end
-          end
+      it 'returns a 200 status' do
+        expect(response.length).to eql(3)
+        expect(response.first).to eql('200')
+      end
 
-          context 'adding an additional header' do
-            before do
-              config.swagger_headers = { 'Access-Control-Allow-Origin' => '*' }
-            end
-            it 'returns a 200 status' do
-              expect(response.length).to eql(3)
-              expect(response.first).to eql('200')
-            end
-
-            it 'applies the headers to the response' do
-              expect(response[1]).to include( 'Access-Control-Allow-Origin' => '*')
-            end
-
-            it 'keeps the default header' do
-              expect(response[1]).to include( 'Content-Type' => 'application/json')
-            end
-          end
-        end
-
-        context "given a path that doesn't map to any swagger file" do
-          let(:env) { env_defaults.merge('PATH_INFO' => 'foobar.json') }
-          before do
-            allow(app).to receive(:call).and_return([ '500', {}, [] ])
-          end
-
-          it 'delegates to the next middleware' do
-            expect(response).to include('500')
-          end
-        end
-
-        context "Disallow path traversing on path info" do
-          let(:env) { env_defaults.merge('PATH_INFO' => '../traverse-secret.yml') }
-          before do
-            allow(app).to receive(:call).and_return([ '500', {}, [] ])
-          end
-
-          it 'delegates to the next middleware' do
-            expect(response).to include('500')
-          end
-        end
-
-        context 'when the env contains a specific swagger_root' do
-          let(:env) do
-            env_defaults.merge(
-              'PATH_INFO' => 'v1/swagger.json',
-              'action_dispatch.request.path_parameters' => {
-                swagger_root: swagger_root
-              }
-            )
-          end
-
-          it 'locates files at the provided swagger_root' do
-            expect(response.length).to eql(3)
-            expect(response[1]).to include( 'Content-Type' => 'application/json')
-            expect(response[2].join).to include('"openapi":"3.0.1"')
-          end
-        end
-
-        context 'when a swagger_filter is configured' do
-          before do
-            config.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
-          end
-          let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.json') }
-
-          it 'applies the filter prior to serialization' do
-            expect(response.length).to eql(3)
-            expect(response[2].join).to include('"host":"tempuri.org"')
-          end
-        end
-
-        context 'when a path maps to a yaml swagger file' do
-          let(:env) { env_defaults.merge('PATH_INFO' => 'v1/swagger.yml') }
-
-          it 'returns a 200 status' do
-            expect(response.length).to eql(3)
-            expect(response.first).to eql('200')
-          end
-
-          it 'returns contents of the swagger file' do
-            expect(response.length).to eql(3)
-            expect(response[1]).to include( 'Content-Type' => 'text/yaml')
-            expect(response[2].join).to include('title: API V1')
-          end
-        end
+      it 'returns contents of the swagger file' do
+        expect(response.length).to eql(3)
+        expect(response[1]).to include('Content-Type' => 'text/yaml')
+        expect(response[2].join).to include('title: API V1')
       end
     end
   end

--- a/rswag-api/spec/spec_helper.rb
+++ b/rswag-api/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 
 RSpec.configure do |config|
@@ -8,3 +10,5 @@ RSpec.configure do |config|
     add_filter %r{^/spec/}
   end
 end
+
+require 'rswag/api'

--- a/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
+++ b/rswag-specs/lib/generators/rswag/specs/install/templates/swagger_helper.rb
@@ -6,15 +6,15 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join('swagger').to_s
+  config.openapi_root = Rails.root.join('swagger').to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
+  # be generated at the provided relative path under openapi_root
   # By default, the operations defined in spec files are added to the first
-  # document below. You can override this behavior by adding a swagger_doc tag to the
-  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
     'v1/swagger.yaml' => {
       openapi: '3.0.1',
       info: {
@@ -36,8 +36,8 @@ RSpec.configure do |config|
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
-  # The swagger_docs configuration option has the filename including format in
+  # The openapi_specs configuration option has the filename including format in
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
-  config.swagger_format = :yaml
+  config.openapi_format = :yaml
 end

--- a/rswag-specs/lib/rswag/specs.rb
+++ b/rswag-specs/lib/rswag/specs.rb
@@ -8,13 +8,22 @@ require 'rswag/specs/railtie' if defined?(Rails::Railtie)
 
 module Rswag
   module Specs
+    RENAMED_METHODS = {
+      swagger_root: :openapi_root,
+      swagger_docs: :openapi_specs,
+      swagger_dry_run: :rswag_dry_run,
+      swagger_format: :openapi_format,
+      swagger_strict_schema_validation: :openapi_strict_schema_validation
+    }.freeze
+    private_constant :RENAMED_METHODS
+
     # Extend RSpec with a swagger-based DSL
     ::RSpec.configure do |c|
-      c.add_setting :swagger_root
-      c.add_setting :swagger_docs
-      c.add_setting :swagger_dry_run
-      c.add_setting :swagger_format
-      c.add_setting :swagger_strict_schema_validation
+      c.add_setting :openapi_root
+      c.add_setting :openapi_specs
+      c.add_setting :rswag_dry_run
+      c.add_setting :openapi_format, default: :json
+      c.add_setting :openapi_strict_schema_validation
       c.extend ExampleGroupHelpers, type: :request
       c.include ExampleHelpers, type: :request
     end
@@ -23,8 +32,31 @@ module Rswag
       @config ||= Configuration.new(RSpec.configuration)
     end
 
+    def self.deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new('3.0', 'rswag-specs')
+    end
+
     # Support Rails 3+ and RSpec 2+ (sigh!)
     RAILS_VERSION = Rails::VERSION::MAJOR
     RSPEC_VERSION = RSpec::Core::Version::STRING.split('.').first.to_i
+
+    RSpec::Core::Configuration.class_eval do
+      RENAMED_METHODS.each do |old_name, new_name|
+        define_method("#{old_name}=") do |*args, &block|
+          public_send("#{new_name}=", *args, &block)
+        end
+      end
+    end
+
+    Specs.deprecator.deprecate_methods(
+      RSpec::Core::Configuration,
+      RENAMED_METHODS.to_h { |old_name, new_name| ["#{old_name}=".to_sym, "#{new_name}=".to_sym] }
+    )
+
+    if RUBY_VERSION.start_with? '2.6'
+      Specs.deprecator.warn('Rswag::Specs: WARNING: Support for Ruby 2.6 will be dropped in v3.0')
+    end
+
+    Specs.deprecator.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0') if RSPEC_VERSION < 3
   end
 end

--- a/rswag-specs/lib/rswag/specs/configuration.rb
+++ b/rswag-specs/lib/rswag/specs/configuration.rb
@@ -7,63 +7,59 @@ module Rswag
         @rspec_config = rspec_config
       end
 
-      def swagger_root
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_root" in v3.0')
-        @swagger_root ||= begin
-          if @rspec_config.swagger_root.nil?
-            raise ConfigurationError, 'No swagger_root provided. See swagger_helper.rb'
+      def openapi_root
+        @openapi_root ||=
+          @rspec_config.openapi_root || raise(ConfigurationError, 'No openapi_root provided. See swagger_helper.rb')
+      end
+
+      def openapi_specs
+        @openapi_specs ||= begin
+          if @rspec_config.openapi_specs.nil? || @rspec_config.openapi_specs.empty?
+            raise ConfigurationError, 'No openapi_specs defined. See swagger_helper.rb'
           end
 
-          @rspec_config.swagger_root
+          @rspec_config.openapi_specs
         end
       end
 
-      def swagger_docs
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_specs" in v3.0')
-        @swagger_docs ||= begin
-          if @rspec_config.swagger_docs.nil? || @rspec_config.swagger_docs.empty?
-            raise ConfigurationError, 'No swagger_docs defined. See swagger_helper.rb'
+      def rswag_dry_run
+        @rswag_dry_run ||= begin
+          if ENV.key?('SWAGGER_DRY_RUN') || ENV.key?('RSWAG_DRY_RUN')
+            @rspec_config.rswag_dry_run = ENV['SWAGGER_DRY_RUN'] == '1' || ENV['RSWAG_DRY_RUN'] == '1'
           end
 
-          @rspec_config.swagger_docs
+          @rspec_config.rswag_dry_run.nil? || @rspec_config.rswag_dry_run
         end
       end
 
-      def swagger_dry_run
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: The method will be renamed to "rswag_dry_run" in v3.0')
-        return @swagger_dry_run if defined? @swagger_dry_run
-        if ENV.key?('SWAGGER_DRY_RUN')
-          @rspec_config.swagger_dry_run = ENV['SWAGGER_DRY_RUN'] == '1'
-        end
-        @swagger_dry_run = @rspec_config.swagger_dry_run.nil? || @rspec_config.swagger_dry_run
-      end
+      def openapi_format
+        @openapi_format ||= begin
+          if @rspec_config.openapi_format.nil? || @rspec_config.openapi_format.empty?
+            @rspec_config.openapi_format = :json
+          end
 
-      def swagger_format
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_format" in v3.0')
-        @swagger_format ||= begin
-          @rspec_config.swagger_format = :json if @rspec_config.swagger_format.nil? || @rspec_config.swagger_format.empty?
-          raise ConfigurationError, "Unknown swagger_format '#{@rspec_config.swagger_format}'" unless [:json, :yaml].include?(@rspec_config.swagger_format)
+          unless [:json, :yaml].include?(@rspec_config.openapi_format)
+            raise ConfigurationError, "Unknown openapi_format '#{@rspec_config.openapi_format}'"
+          end
 
-          @rspec_config.swagger_format
+          @rspec_config.openapi_format
         end
       end
 
-      def get_swagger_doc(name)
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: The method will be renamed to "get_openapi_spec" in v3.0')
-        return swagger_docs.values.first if name.nil?
-        raise ConfigurationError, "Unknown swagger_doc '#{name}'" unless swagger_docs[name]
+      def get_openapi_spec(name)
+        return openapi_specs.values.first if name.nil?
+        raise ConfigurationError, "Unknown openapi_spec '#{name}'" unless openapi_specs[name]
 
-        swagger_docs[name]
+        openapi_specs[name]
       end
 
-      def get_swagger_doc_version(name)
-        doc = get_swagger_doc(name)
+      def get_openapi_spec_version(name)
+        doc = get_openapi_spec(name)
         doc[:openapi] || doc[:swagger]
       end
 
-      def swagger_strict_schema_validation
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: The method will be renamed to "openapi_strict_schema_validation" in v3.0')
-        @swagger_strict_schema_validation ||= (@rspec_config.swagger_strict_schema_validation || false)
+      def openapi_strict_schema_validation
+        @rspec_config.openapi_strict_schema_validation || false
       end
     end
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -5,8 +5,6 @@ require 'active_support'
 module Rswag
   module Specs
     module ExampleGroupHelpers
-      ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for Ruby 2.6 will be dropped in v3.0') if RUBY_VERSION.start_with? '2.6'
-
       def path(template, metadata = {}, &block)
         metadata[:path_item] = { template: template }
         describe(template, metadata, &block)
@@ -129,7 +127,6 @@ module Rswag
         description ||= "returns a #{metadata[:response][:code]} response"
 
         if RSPEC_VERSION < 3
-          ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
           before do
             submit_request(example.metadata)
           end

--- a/rswag-specs/lib/rswag/specs/railtie.rb
+++ b/rswag-specs/lib/rswag/specs/railtie.rb
@@ -8,7 +8,13 @@ module Rswag
       end
 
       generators do
-        require 'generators/rspec/swagger_generator.rb'
+        require 'generators/rspec/swagger_generator'
+      end
+
+      initializer 'rswag-specs.deprecator' do |app|
+        if app.respond_to?(:deprecators)
+          app.deprecators[:rswag_specs] = Rswag::Specs.deprecator
+        end
       end
     end
   end

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -12,7 +12,7 @@ module Rswag
       end
 
       def build_request(metadata, example)
-        swagger_doc = @config.get_swagger_doc(metadata[:swagger_doc])
+        swagger_doc = @config.get_openapi_spec(metadata[:openapi_spec] || metadata[:swagger_doc])
         parameters = expand_parameters(metadata, swagger_doc, example)
 
         {}.tap do |request|
@@ -53,7 +53,7 @@ module Rswag
           (swagger_doc[:securityDefinitions] || {}).slice(*scheme_names).values
         else # Openapi3
           if swagger_doc.key?(:securityDefinitions)
-            ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
+            Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: securityDefinitions is replaced in OpenAPI3! Rename to components/securitySchemes (in swagger_helper.rb)')
             swagger_doc[:components] ||= { securitySchemes: swagger_doc[:securityDefinitions] }
             swagger_doc.delete(:securityDefinitions)
           end
@@ -75,7 +75,7 @@ module Rswag
           ref.sub('#/parameters/', '').to_sym
         else # Openapi3
           if ref.start_with?('#/parameters/')
-            ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
+            Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: #/parameters/ refs are replaced in OpenAPI3! Rename to #/components/parameters/')
             ref.sub('#/parameters/', '').to_sym
           else
             ref.sub('#/components/parameters/', '').to_sym
@@ -88,7 +88,7 @@ module Rswag
           swagger_doc[:parameters]
         else # Openapi3
           if swagger_doc.key?(:parameters)
-            ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
+            Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: parameters is replaced in OpenAPI3! Rename to components/parameters (in swagger_helper.rb)')
             swagger_doc[:parameters]
           else
             components = swagger_doc[:components] || {}
@@ -115,7 +115,7 @@ module Rswag
         uses_base_path = swagger_doc[:basePath].present?
 
         if open_api_3_doc && uses_base_path
-          ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: basePath is replaced in OpenAPI3! Update your swagger_helper.rb')
+          Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: basePath is replaced in OpenAPI3! Update your swagger_helper.rb')
         end
 
         if uses_base_path

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -18,10 +18,9 @@ namespace :rswag do
 
       t.rspec_opts = [additional_rspec_opts]
 
-      if Rswag::Specs::RSPEC_VERSION > 2 && Rswag::Specs.config.swagger_dry_run
+      if Rswag::Specs.config.rswag_dry_run
         t.rspec_opts += ['--format Rswag::Specs::SwaggerFormatter', '--dry-run', '--order defined']
       else
-        ActiveSupport::Deprecation.warn('Rswag::Specs: WARNING: Support for RSpec 2.X will be dropped in v3.0')
         t.rspec_opts += ['--format Rswag::Specs::SwaggerFormatter', '--order defined']
       end
     end

--- a/rswag-specs/spec/rswag/specs/configuration_spec.rb
+++ b/rswag-specs/spec/rswag/specs/configuration_spec.rb
@@ -1,101 +1,192 @@
 # frozen_string_literal: true
 
 require 'rswag/specs/configuration'
+require 'climate_control'
 
-module Rswag
-  module Specs
-    RSpec.describe Configuration do
-      subject { described_class.new(rspec_config) }
+RSpec.describe Rswag::Specs::Configuration do
+  subject { described_class.new(rspec_config) }
 
-      let(:rspec_config) do
-        OpenStruct.new(swagger_root: swagger_root, swagger_docs: swagger_docs, swagger_format: swagger_format)
-      end
-      let(:swagger_root) { 'foobar' }
-      let(:swagger_docs) do
-        {
-          'v1/swagger.json' => { info: { title: 'v1' } },
-          'v2/swagger.json' => { info: { title: 'v2' } }
-        }
-      end
-      let(:swagger_format) { :yaml }
+  let(:rspec_config) do
+    OpenStruct.new(openapi_root: openapi_root, openapi_specs: openapi_specs, openapi_format: openapi_format,
+                   rswag_dry_run: rswag_dry_run, openapi_strict_schema_validation: openapi_strict_schema_validation)
+  end
+  let(:openapi_root) { 'foobar' }
+  let(:openapi_specs) do
+    {
+      'v1/swagger.json' => { swagger: '2.0.0', info: { title: 'v1' } },
+      'v2/swagger.json' => { openapi: '3.0.0', info: { title: 'v2' } }
+    }
+  end
+  let(:openapi_format) { :yaml }
+  let(:rswag_dry_run) { nil }
+  let(:openapi_strict_schema_validation) { nil }
 
-      describe '#swagger_root' do
-        let(:response) { subject.swagger_root }
+  describe '#openapi_root' do
+    let(:response) { subject.openapi_root }
 
-        context 'provided in rspec config' do
-          it { expect(response).to eq('foobar') }
-        end
+    context 'provided in rspec config' do
+      it { expect(response).to eq('foobar') }
+    end
 
-        context 'not provided' do
-          let(:swagger_root) { nil }
-          it { expect { response }.to raise_error ConfigurationError }
-        end
-      end
+    context 'not provided' do
+      let(:openapi_root) { nil }
+      it { expect { response }.to raise_error Rswag::Specs::ConfigurationError }
+    end
+  end
 
-      describe '#swagger_docs' do
-        let(:response) { subject.swagger_docs }
+  describe '#openapi_specs' do
+    let(:response) { subject.openapi_specs }
 
-        context 'provided in rspec config' do
-          it { expect(response).to be_an_instance_of(Hash) }
-        end
+    context 'provided in rspec config' do
+      it { expect(response).to be_an_instance_of(Hash) }
+    end
 
-        context 'not provided' do
-          let(:swagger_docs) { nil }
-          it { expect { response }.to raise_error ConfigurationError }
-        end
+    context 'not provided' do
+      let(:openapi_specs) { nil }
+      it { expect { response }.to raise_error Rswag::Specs::ConfigurationError }
+    end
 
-        context 'provided but empty' do
-          let(:swagger_docs) { {} }
-          it { expect { response }.to raise_error ConfigurationError }
-        end
-      end
+    context 'provided but empty' do
+      let(:openapi_specs) { {} }
+      it { expect { response }.to raise_error Rswag::Specs::ConfigurationError }
+    end
+  end
 
-      describe '#swagger_format' do
-        let(:response) { subject.swagger_format }
+  describe '#openapi_format' do
+    let(:response) { subject.openapi_format }
 
-        context 'provided in rspec config' do
-          it { expect(response).to be_an_instance_of(Symbol) }
-        end
+    context 'provided in rspec config' do
+      it { expect(response).to be_an_instance_of(Symbol) }
+    end
 
-        context 'unsupported format provided' do
-          let(:swagger_format) { :xml }
+    context 'unsupported format provided' do
+      let(:openapi_format) { :xml }
 
-          it { expect { response }.to raise_error ConfigurationError }
-        end
+      it { expect { response }.to raise_error Rswag::Specs::ConfigurationError }
+    end
 
-        context 'not provided' do
-          let(:swagger_format) { nil }
+    context 'not provided' do
+      let(:openapi_format) { nil }
 
-          it { expect(response).to eq(:json) }
-        end
-      end
+      it { expect(response).to eq(:json) }
+    end
+  end
 
-      describe '#get_swagger_doc(tag=nil)' do
-        let(:swagger_doc) { subject.get_swagger_doc(tag) }
+  describe '#rswag_dry_run' do
+    let(:response) { subject.rswag_dry_run }
 
-        context 'no tag provided' do
-          let(:tag) { nil }
+    context 'when not provided' do
+      let(:rswag_dry_run) { nil }
+      it { expect(response).to eq(true) }
+    end
 
-          it 'returns the first doc in rspec config' do
-            expect(swagger_doc).to eq(info: { title: 'v1' })
-          end
-        end
-
-        context 'tag provided' do
-          context 'matching doc' do
-            let(:tag) { 'v2/swagger.json' }
-
-            it 'returns the matching doc in rspec config' do
-              expect(swagger_doc).to eq(info: { title: 'v2' })
-            end
-          end
-
-          context 'no matching doc' do
-            let(:tag) { 'foobar' }
-            it { expect { swagger_doc }.to raise_error ConfigurationError }
+    context 'when environment variable is provided' do
+      context 'when set to 0' do
+        it 'returns false' do
+          ClimateControl.modify RSWAG_DRY_RUN: '0' do
+            expect(response).to eq(false)
           end
         end
       end
+
+      context 'when set to 1' do
+        it 'returns true' do
+          ClimateControl.modify RSWAG_DRY_RUN: '1' do
+            expect(response).to eq(true)
+          end
+        end
+      end
+    end
+
+    context 'when deprecated environment variable is provided' do
+      context 'when set to 0' do
+        it 'returns false' do
+          ClimateControl.modify SWAGGER_DRY_RUN: '0' do
+            expect(response).to eq(false)
+          end
+        end
+      end
+
+      context 'when set to 1' do
+        it 'returns true' do
+          ClimateControl.modify SWAGGER_DRY_RUN: '1' do
+            expect(response).to eq(true)
+          end
+        end
+      end
+    end
+
+    context 'when provided in rspec config' do
+      let(:rswag_dry_run) { false }
+      it { expect(response).to eq(false) }
+    end
+  end
+
+  describe '#get_openapi_spec(tag=nil)' do
+    let(:openapi_spec) { subject.get_openapi_spec(tag) }
+
+    context 'no tag provided' do
+      let(:tag) { nil }
+
+      it 'returns the first doc in rspec config' do
+        expect(openapi_spec).to match hash_including(info: { title: 'v1' })
+      end
+    end
+
+    context 'tag provided' do
+      context 'matching doc' do
+        let(:tag) { 'v2/swagger.json' }
+
+        it 'returns the matching doc in rspec config' do
+          expect(openapi_spec).to match hash_including(info: { title: 'v2' })
+        end
+      end
+
+      context 'no matching doc' do
+        let(:tag) { 'foobar' }
+        it { expect { openapi_spec }.to raise_error Rswag::Specs::ConfigurationError }
+      end
+    end
+  end
+
+  describe '#get_openapi_spec_version' do
+    let(:response) { subject.get_openapi_spec_version(tag) }
+
+    context 'when tag provided' do
+      context 'with matching doc' do
+        let(:tag) { 'v2/swagger.json' }
+
+        it 'returns the matching version in rspec config' do
+          expect(response).to eq('3.0.0')
+        end
+      end
+
+      context 'with no matching doc' do
+        let(:tag) { 'foobar' }
+        it { expect { response }.to raise_error Rswag::Specs::ConfigurationError }
+      end
+    end
+
+    context 'when no tag provided' do
+      let(:tag) { nil }
+
+      it 'returns the first version in rspec config' do
+        expect(response).to eq('2.0.0')
+      end
+    end
+  end
+
+  describe '#openapi_strict_schema_validation' do
+    let(:response) { subject.openapi_strict_schema_validation }
+
+    context 'when not provided' do
+      let(:openapi_strict_schema_validation) { nil }
+      it { expect(response).to eq(false) }
+    end
+
+    context 'when provided in rspec config' do
+      let(:openapi_strict_schema_validation) { true }
+      it { expect(response).to eq(true) }
     end
   end
 end

--- a/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_helpers_spec.rb
@@ -10,11 +10,11 @@ module Rswag
       before do
         subject.extend(ExampleHelpers)
         allow(Rswag::Specs).to receive(:config).and_return(config)
-        allow(config).to receive(:get_swagger_doc).and_return(swagger_doc)
+        allow(config).to receive(:get_openapi_spec).and_return(openapi_spec)
         stub_const('Rswag::Specs::RAILS_VERSION', 3)
       end
       let(:config) { double('config') }
-      let(:swagger_doc) do
+      let(:openapi_spec) do
         {
           swagger: '2.0',
           securityDefinitions: {

--- a/rswag-specs/spec/rswag/specs_spec.rb
+++ b/rswag-specs/spec/rswag/specs_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Rswag::Specs do
+  describe 'settings' do
+    let(:rspec_config) do
+      RSpec::Core::Configuration.new.tap do |c|
+        c.add_setting :openapi_root
+      end
+    end
+
+    it 'defines openapi settings' do
+      expect { rspec_config.openapi_root = 'foobar' }.not_to raise_error
+    end
+
+    it 'defines deprecated swagger settings' do
+      allow(Rswag::Specs.deprecator).to receive(:warn)
+      rspec_config.swagger_root = 'foobar'
+      expect(rspec_config.openapi_root).to eq('foobar')
+      expect(Rswag::Specs.deprecator).to(
+        have_received(:warn)
+          .with('swagger_root= is deprecated and will be removed from rswag-specs 3.0 (use openapi_root= instead)',
+                any_args)
+      )
+    end
+  end
+
+  describe '::config' do
+    it 'returns a configuration object' do
+      expect(described_class.config).to be_a Rswag::Specs::Configuration
+    end
+  end
+end

--- a/rswag-ui/lib/generators/rswag/ui/install/templates/rswag_ui.rb
+++ b/rswag-ui/lib/generators/rswag/ui/install/templates/rswag_ui.rb
@@ -5,7 +5,7 @@ Rswag::Ui.configure do |c|
   # host) to the corresponding endpoint and the second is a title that will be
   # displayed in the document selector.
   # NOTE: If you're using rspec-api to expose Swagger files
-  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
   c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'

--- a/rswag-ui/lib/rswag/ui.rb
+++ b/rswag-ui/lib/rswag/ui.rb
@@ -10,5 +10,9 @@ module Rswag
     def self.config
       @config ||= Configuration.new
     end
+
+    def self.deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new('3.0', 'rswag-ui')
+    end
   end
 end

--- a/rswag-ui/lib/rswag/ui/configuration.rb
+++ b/rswag-ui/lib/rswag/ui/configuration.rb
@@ -26,7 +26,11 @@ module Rswag
       end
 
       def swagger_endpoint(url, name)
-        ActiveSupport::Deprecation.warn('Rswag::Ui: WARNING: The method will be renamed to "openapi_endpoint" in v3.0')
+        Rswag::Ui.deprecator.warn('Rswag::Ui: WARNING: The method will be renamed to "openapi_endpoint" in v3.0')
+        openapi_endpoint(url, name)
+      end
+
+      def openapi_endpoint(url, name)
         @config_object[:urls] ||= []
         @config_object[:urls] << { url: url, name: name }
       end

--- a/test-app/config/initializers/rswag-api.rb
+++ b/test-app/config/initializers/rswag-api.rb
@@ -4,7 +4,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.to_s + '/swagger'
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/test-app/config/initializers/rswag-ui.rb
+++ b/test-app/config/initializers/rswag-ui.rb
@@ -6,5 +6,5 @@ Rswag::Ui.configure do |c|
   # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON endpoints,
   # then the list below should correspond to the relative paths for those endpoints
 
-  c.swagger_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
+  c.openapi_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'
 end

--- a/test-app/config/initializers/rswag-ui.rb
+++ b/test-app/config/initializers/rswag-ui.rb
@@ -3,7 +3,7 @@ Rswag::Ui.configure do |c|
   # List the Swagger endpoints that you want to be documented through the swagger-ui
   # The first parameter is the path (absolute or relative to the UI host) to the corresponding
   # JSON endpoint and the second is a title that will be displayed in the document selector
-  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON endpoints,
+  # NOTE: If you're using rspec-api to expose Swagger files (under openapi_root) as JSON endpoints,
   # then the list below should correspond to the relative paths for those endpoints
 
   c.openapi_endpoint '/api-docs/v1/swagger.json', 'API V1 Docs'

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 

--- a/test-app/spec/integration/auth_tests_spec.rb
+++ b/test-app/spec/integration/auth_tests_spec.rb
@@ -2,9 +2,9 @@
 
 require 'swagger_helper'
 
-RSpec.describe 'Auth Tests API', type: :request, swagger_doc: 'v1/swagger.json' do
+RSpec.describe 'Auth Tests API', type: :request, openapi_spec: 'v1/swagger.json' do
   before do
-    allow(ActiveSupport::Deprecation).to receive(:warn) # Silence deprecation output from specs
+    allow(Rswag::Specs.deprecator).to receive(:warn) # Silence deprecation output from specs
   end
 
   path '/auth-tests/basic' do

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -1,10 +1,10 @@
 require 'swagger_helper'
 
-RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
+RSpec.describe 'Blogs API', type: :request, openapi_spec: 'v1/swagger.json' do
   let(:api_key) { 'fake_key' }
 
   before do
-    allow(ActiveSupport::Deprecation).to receive(:warn) # Silence deprecation output from specs
+    # allow(Rswag::Specs.deprecator).to receive(:warn) # Silence deprecation output from specs
   end
 
   path '/blogs' do
@@ -14,7 +14,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       operationId 'createBlog'
       consumes 'application/json'
       produces 'application/json'
-      parameter name: :blog, in: :body, schema: { '$ref' => '#/definitions/blog' }
+      parameter name: :blog, in: :body, schema: { '$ref' => '#/components/schemas/blog' }
 
       let(:blog) { { title: 'foo', content: 'bar', status: 'published' } }
 
@@ -24,7 +24,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       end
 
       response "422", "invalid request" do
-        schema "$ref" => "#/definitions/errors_object"
+        schema "$ref" => "#/components/schemas/errors_object"
 
         let(:blog) { {title: "foo"} }
 
@@ -53,7 +53,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       let(:blog_status) { 'published' }
 
       response '200', 'success' do
-        schema type: 'array', items: { '$ref' => '#/definitions/blog' }
+        schema type: 'array', items: { '$ref' => '#/components/schemas/blog' }
 
         run_test! do
           expect(JSON.parse(response.body).size).to eq(1)
@@ -61,7 +61,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       end
 
       response '200', 'no content' do
-        schema type: 'array', items: { '$ref' => '#/definitions/blog' }
+        schema type: 'array', items: { '$ref' => '#/components/schemas/blog' }
 
         let(:blog_status) { 'invalid' }
 
@@ -95,7 +95,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
       let(:flexible_blog) { { blog: { headline: 'my headline', text: 'my text' } } }
 
       response '201', 'flexible blog created' do
-        schema oneOf: [{ '$ref' => '#/definitions/blog' }, { '$ref' => '#/definitions/flexible_blog' }]
+        schema oneOf: [{ '$ref' => '#/components/schemas/blog' }, { '$ref' => '#/components/schemas/flexible_blog' }]
         run_test!
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
         header 'Last-Modified', type: :string
         header 'Cache-Control', type: :string
 
-        schema '$ref' => '#/definitions/blog'
+        schema '$ref' => '#/components/schemas/blog'
 
         #Legacy
         examples 'application/json' => {
@@ -146,8 +146,8 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
 
         run_test!
 
-        context 'when swagger_strict_schema_validation is true' do
-          run_test!(swagger_strict_schema_validation: true)
+        context 'when openapi_strict_schema_validation is true' do
+          run_test!(openapi_strict_schema_validation: true)
         end
       end
 
@@ -156,8 +156,8 @@ RSpec.describe 'Blogs API', type: :request, swagger_doc: 'v1/swagger.json' do
         run_test!
       end
 
-      response '200', 'blog found - swagger_strict_schema_validation = true', swagger_strict_schema_validation: true do
-        schema '$ref' => '#/definitions/blog'
+      response '200', 'blog found - openapi_strict_schema_validation = true', openapi_strict_schema_validation: true do
+        schema '$ref' => '#/components/schemas/blog'
 
         let(:id) { blog.id }
 

--- a/test-app/spec/integration/openapi3_spec.rb
+++ b/test-app/spec/integration/openapi3_spec.rb
@@ -5,11 +5,11 @@ require 'rswag/specs/swagger_formatter'
 # Specifically here, we look at OpenApi 3 as documented at
 # https://swagger.io/docs/specification/about/
 
-RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.json' do
+RSpec.describe 'Generated OpenApi', type: :request, openapi_spec: 'v3/openapi.json' do
   before do |example|
     output = double('output').as_null_object
-    swagger_root = File.expand_path('tmp/swagger', __dir__)
-    config = double('config', swagger_root: swagger_root, get_swagger_doc: swagger_doc )
+    openapi_root = File.expand_path('tmp/swagger', __dir__)
+    config = double('config', openapi_root: openapi_root, get_openapi_spec: openapi_spec)
     formatter = Rswag::Specs::SwaggerFormatter.new(output, config)
 
     example_group = OpenStruct.new(group: OpenStruct.new(metadata: example.metadata))
@@ -17,7 +17,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
   end
 
   # Framework definition, to be overridden for contexts
-  let(:swagger_doc) do
+  let(:openapi_spec) do
     { # That which would be defined in swagger_helper.rb
       openapi: api_openapi,
       info: {},
@@ -42,7 +42,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
           run_test!
 
           it 'lists server' do
-            tree = swagger_doc.dig(:servers)
+            tree = openapi_spec.dig(:servers)
             expect(tree).to eq([
               { url: "https://api.example.com/foo" }
             ])
@@ -55,7 +55,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
             ]}
 
             it 'lists servers' do
-              tree = swagger_doc.dig(:servers)
+              tree = openapi_spec.dig(:servers)
               expect(tree).to eq([
                 { url: "https://api.example.com/foo" },
                 { url: "http://api.example.com/foo" }
@@ -74,7 +74,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
             }]}
 
             it 'lists server and variables' do
-              tree = swagger_doc.dig(:servers)
+              tree = openapi_spec.dig(:servers)
               expect(tree).to eq([{
                 url: "https://{defaultHost}/foo",
                 variables: {
@@ -102,7 +102,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
 
           it 'declares output as application/json' do
             pending "Not yet implemented?"
-            tree = swagger_doc.dig(:paths, "/stubs", :get, :responses, '200', :content)
+            tree = openapi_spec.dig(:paths, "/stubs", :get, :responses, '200', :content)
             expect(tree).to have_key('application/json')
           end
         end
@@ -129,13 +129,13 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
             run_test!
 
             it 'declares parameter in path' do
-              tree = swagger_doc.dig(:paths, "/stubs/{a_param}", :get, :parameters)
+              tree = openapi_spec.dig(:paths, "/stubs/{a_param}", :get, :parameters)
               expect(tree.first[:name]).to eq('a_param')
               expect(tree.first[:in]).to eq(:path)
             end
 
             it 'declares path parameters as required' do
-              tree = swagger_doc.dig(:paths, "/stubs/{a_param}", :get, :parameters)
+              tree = openapi_spec.dig(:paths, "/stubs/{a_param}", :get, :parameters)
               expect(tree.first[:required]).to eq(true)
             end
           end
@@ -159,7 +159,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
             run_test!
 
             it 'declares parameter in query string' do
-              tree = swagger_doc.dig(:paths, "/stubs", :get, :parameters)
+              tree = openapi_spec.dig(:paths, "/stubs", :get, :parameters)
               expect(tree.first[:name]).to eq('a_param')
               expect(tree.first[:in]).to eq(:query)
             end
@@ -195,7 +195,7 @@ RSpec.describe 'Generated OpenApi', type: :request, swagger_doc: 'v3/openapi.jso
 
           it 'declares requestBody is required' do
             pending "This output is massaged in SwaggerFormatter#stop, and isn't quite ready here to assert"
-            tree = swagger_doc.dig(:paths, "/stubs", :post, :requestBody)
+            tree = openapi_spec.dig(:paths, "/stubs", :post, :requestBody)
             expect(tree[:required]).to eq(true)
           end
         end

--- a/test-app/spec/rake/rswag_specs_swaggerize_spec.rb
+++ b/test-app/spec/rake/rswag_specs_swaggerize_spec.rb
@@ -4,14 +4,15 @@ require 'spec_helper'
 require 'rake'
 
 RSpec.describe 'rswag:specs:swaggerize' do
-  let(:swagger_root) { Rails.root.to_s + '/swagger' }
+  let(:openapi_root) { Rails.root.to_s + '/swagger' }
+
   before do
     TestApp::Application.load_tasks
-    FileUtils.rm_r(swagger_root) if File.exist?(swagger_root)
+    FileUtils.rm_r(openapi_root) if File.exist?(openapi_root)
   end
 
   it 'generates Swagger JSON files from integration specs' do
     Rake::Task['rswag:specs:swaggerize'].invoke
-    expect(File).to exist("#{swagger_root}/v1/swagger.json")
+    expect(File).to exist("#{openapi_root}/v1/swagger.json")
   end
 end

--- a/test-app/spec/swagger_helper.rb
+++ b/test-app/spec/swagger_helper.rb
@@ -6,15 +6,15 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.to_s + '/swagger'
-  config.swagger_dry_run = false
+  config.openapi_root = Rails.root.to_s + '/swagger'
+  config.rswag_dry_run = false
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:to_swagger' rake task, the complete Swagger will
-  # be generated at the provided relative path under swagger_root
+  # be generated at the provided relative path under openapi_root
   # By default, the operations defined in spec files are added to the first
-  # document below. You can override this behavior by adding a swagger_doc tag to the
-  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
-  config.swagger_docs = {
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
     'v1/swagger.json' => {
       openapi: '3.0.0',
       info: {
@@ -35,41 +35,6 @@ RSpec.configure do |config|
           }
         }
       ],
-      definitions: {
-        errors_object: {
-          type: 'object',
-          properties: {
-            errors: { '$ref' => '#/definitions/errors_map' }
-          }
-        },
-        errors_map: {
-          type: 'object',
-          additionalProperties: {
-            type: 'array',
-            items: { type: 'string' }
-          }
-        },
-        blog: {
-          type: 'object',
-          properties: {
-            id: { type: 'integer' },
-            title: { type: 'string' },
-            content: { type: 'string', 'x-nullable': true },
-            thumbnail: { type: 'string', 'x-nullable': true}
-          },
-          required: [ 'id', 'title' ]
-        },
-        flexible_blog: {
-          type: 'object',
-          properties: {
-            id: { type: 'integer' },
-            headline: { type: 'string' },
-            text: { type: 'string', nullable: true },
-            thumbnail: { type: 'string', nullable: true }
-          },
-          required: ['id', 'headline']
-        }
-      },
       components: {
         securitySchemes: {
           basic_auth: {
@@ -80,6 +45,41 @@ RSpec.configure do |config|
             type: :apiKey,
             name: 'api_key',
             in: :query
+          }
+        },
+        schemas: {
+          errors_object: {
+            type: 'object',
+            properties: {
+              errors: { '$ref' => '#/components/schemas/errors_map' }
+            }
+          },
+          errors_map: {
+            type: 'object',
+            additionalProperties: {
+              type: 'array',
+              items: { type: 'string' }
+            }
+          },
+          blog: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              title: { type: 'string' },
+              content: { type: 'string', 'x-nullable': true },
+              thumbnail: { type: 'string', 'x-nullable': true}
+            },
+            required: [ 'id', 'title' ]
+          },
+          flexible_blog: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              headline: { type: 'string' },
+              text: { type: 'string', nullable: true },
+              thumbnail: { type: 'string', nullable: true }
+            },
+            required: ['id', 'headline']
           }
         }
       }
@@ -101,41 +101,6 @@ RSpec.configure do |config|
           }
         }
       ],
-      definitions: {
-        errors_object: {
-          type: 'object',
-          properties: {
-            errors: { '$ref' => '#/definitions/errors_map' }
-          }
-        },
-        errors_map: {
-          type: 'object',
-          additionalProperties: {
-            type: 'array',
-            items: { type: 'string' }
-          }
-        },
-        blog: {
-          type: 'object',
-          properties: {
-            id: { type: 'integer' },
-            title: { type: 'string' },
-            content: { type: 'string', 'x-nullable': true },
-            thumbnail: { type: 'string', 'x-nullable': true}
-          },
-          required: [ 'id', 'title' ]
-        },
-        flexible_blog: {
-          type: 'object',
-          properties: {
-            id: { type: 'integer' },
-            headline: { type: 'string' },
-            text: { type: 'string', nullable: true },
-            thumbnail: { type: 'string', nullable: true }
-          },
-          required: ['id', 'headline']
-        }
-      },
       components: {
         securitySchemes: {
           basic_auth: {
@@ -146,6 +111,41 @@ RSpec.configure do |config|
             type: :apiKey,
             name: 'api_key',
             in: :query
+          }
+        },
+        schemas: {
+          errors_object: {
+            type: 'object',
+            properties: {
+              errors: { '$ref' => '#/components/errors_map' }
+            }
+          },
+          errors_map: {
+            type: 'object',
+            additionalProperties: {
+              type: 'array',
+              items: { type: 'string' }
+            }
+          },
+          blog: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              title: { type: 'string' },
+              content: { type: 'string', 'x-nullable': true },
+              thumbnail: { type: 'string', 'x-nullable': true}
+            },
+            required: [ 'id', 'title' ]
+          },
+          flexible_blog: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              headline: { type: 'string' },
+              text: { type: 'string', nullable: true },
+              thumbnail: { type: 'string', nullable: true }
+            },
+            required: ['id', 'headline']
           }
         }
       }

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -14,7 +14,9 @@
         "operationId": "testBasicAuth",
         "security": [
           {
-            "basic_auth": []
+            "basic_auth": [
+
+            ]
           }
         ],
         "responses": {
@@ -36,7 +38,9 @@
         "operationId": "testApiKey",
         "security": [
           {
-            "api_key": []
+            "api_key": [
+
+            ]
           }
         ],
         "responses": {
@@ -58,8 +62,12 @@
         "operationId": "testBasicAndApiKey",
         "security": [
           {
-            "basic_auth": [],
-            "api_key": []
+            "basic_auth": [
+
+            ],
+            "api_key": [
+
+            ]
           }
         ],
         "responses": {
@@ -80,7 +88,9 @@
         ],
         "description": "Creates a new blog from provided data",
         "operationId": "createBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "201": {
             "description": "blog created"
@@ -90,7 +100,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/definitions/errors_object"
+                  "$ref": "#/components/schemas/errors_object"
                 }
               }
             }
@@ -100,7 +110,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/definitions/blog"
+                "$ref": "#/components/schemas/blog"
               }
             }
           }
@@ -137,7 +147,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/blog"
+                    "$ref": "#/components/schemas/blog"
                   }
                 }
               }
@@ -157,7 +167,9 @@
         ],
         "description": "Creates a flexible blog from provided data",
         "operationId": "createFlexibleBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "201": {
             "description": "flexible blog created",
@@ -166,10 +178,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/definitions/blog"
+                      "$ref": "#/components/schemas/blog"
                     },
                     {
-                      "$ref": "#/definitions/flexible_blog"
+                      "$ref": "#/components/schemas/flexible_blog"
                     }
                   ]
                 }
@@ -215,7 +227,7 @@
         "operationId": "getBlog",
         "responses": {
           "200": {
-            "description": "blog found",
+            "description": "blog found - openapi_strict_schema_validation = true",
             "headers": {
               "ETag": {
                 "type": "string"
@@ -258,7 +270,7 @@
                   }
                 },
                 "schema": {
-                  "$ref": "#/definitions/blog"
+                  "$ref": "#/components/schemas/blog"
                 }
               }
             }
@@ -287,7 +299,9 @@
         ],
         "description": "Upload a thumbnail for specific blog by id",
         "operationId": "uploadThumbnailBlog",
-        "parameters": [],
+        "parameters": [
+
+        ],
         "responses": {
           "200": {
             "description": "blog updated"
@@ -309,79 +323,17 @@
   },
   "servers": [
     {
-      "url": "https://{defaultHost}",
+      "url": "{protocol}://{defaultHost}",
       "variables": {
+        "protocol": {
+          "default": "https"
+        },
         "defaultHost": {
           "default": "www.example.com"
         }
       }
     }
   ],
-  "definitions": {
-    "errors_object": {
-      "type": "object",
-      "properties": {
-        "errors": {
-          "$ref": "#/definitions/errors_map"
-        }
-      }
-    },
-    "errors_map": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      }
-    },
-    "blog": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "content": {
-          "type": "string",
-          "x-nullable": true
-        },
-        "thumbnail": {
-          "type": "string",
-          "x-nullable": true
-        }
-      },
-      "required": [
-        "id",
-        "title"
-      ]
-    },
-    "flexible_blog": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "headline": {
-          "type": "string"
-        },
-        "text": {
-          "type": "string",
-          "nullable": true
-        },
-        "thumbnail": {
-          "type": "string",
-          "nullable": true
-        }
-      },
-      "required": [
-        "id",
-        "headline"
-      ]
-    }
-  },
   "components": {
     "securitySchemes": {
       "basic_auth": {
@@ -392,6 +344,71 @@
         "type": "apiKey",
         "name": "api_key",
         "in": "query"
+      }
+    },
+    "schemas": {
+      "errors_object": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "$ref": "#/components/schemas/errors_map"
+          }
+        }
+      },
+      "errors_map": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "blog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "x-nullable": true
+          },
+          "thumbnail": {
+            "type": "string",
+            "x-nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ]
+      },
+      "flexible_blog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "headline": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          },
+          "thumbnail": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "headline"
+        ]
       }
     }
   }

--- a/test-app/swagger/v3/openapi.json
+++ b/test-app/swagger/v3/openapi.json
@@ -79,71 +79,6 @@
       }
     }
   ],
-  "definitions": {
-    "errors_object": {
-      "type": "object",
-      "properties": {
-        "errors": {
-          "$ref": "#/definitions/errors_map"
-        }
-      }
-    },
-    "errors_map": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      }
-    },
-    "blog": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        },
-        "content": {
-          "type": "string",
-          "x-nullable": true
-        },
-        "thumbnail": {
-          "type": "string",
-          "x-nullable": true
-        }
-      },
-      "required": [
-        "id",
-        "title"
-      ]
-    },
-    "flexible_blog": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer"
-        },
-        "headline": {
-          "type": "string"
-        },
-        "text": {
-          "type": "string",
-          "nullable": true
-        },
-        "thumbnail": {
-          "type": "string",
-          "nullable": true
-        }
-      },
-      "required": [
-        "id",
-        "headline"
-      ]
-    }
-  },
   "components": {
     "securitySchemes": {
       "basic_auth": {
@@ -154,6 +89,71 @@
         "type": "apiKey",
         "name": "api_key",
         "in": "query"
+      }
+    },
+    "schemas": {
+      "errors_object": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "$ref": "#/components/errors_map"
+          }
+        }
+      },
+      "errors_map": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "blog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "x-nullable": true
+          },
+          "thumbnail": {
+            "type": "string",
+            "x-nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ]
+      },
+      "flexible_blog": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "headline": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string",
+            "nullable": true
+          },
+          "thumbnail": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "headline"
+        ]
       }
     }
   }


### PR DESCRIPTION
## Problem
Version 2.12.0 added deprecation warnings to several configuration options without adding the alternative options to resolve the warnings.

## Solution
This pull request uses `ActiveSupport::Deprecation#deprecate_methods` to correctly warn users about the deprecated settings on the `RSpec` configuration object.

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md
- [x] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)
