### PR TITLE
docs: update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Add deprecation warnings for `Rswag::Api` configuration (https://github.com/rswag/rswag/pull/702)
-
 ### Changed
 
 ### Fixed
 
-- Fix deprecation warnings for `Rswag::Specs` configuration (https://github.com/rswag/rswag/pull/702)
-
 ### Documentation
+
+## [2.13.0]
+
+### Added
+
+- Add deprecation warnings for `Rswag::Api` configuration (https://github.com/rswag/rswag/pull/702)
+
+### Fixed
+
+- Fix deprecation warnings for `Rswag::Specs` configuration (https://github.com/rswag/rswag/pull/702)
 
 ## [2.12.0]
 


### PR DESCRIPTION
Releasing fixes in #702 as 2.13.0 since functionality in `rswag-api` has been marked as deprecated.