### PR TITLE
CI: Tell dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Tell Dependabot to update GitHub Actions (https://github.com/rswag/rswag/pull/707)
+
 ### Changed
 
 ### Fixed


### PR DESCRIPTION
## Problem

Sometimes, GitHub Actions become stale, and emit deprecation warnings.

## Solution

Let GitHub's dependabot update those that it knows about, automatically, using PRs.

### Related Issues
n/a

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce

-
