### PR TITLE
Rename ENV PATTERN to RSWAG_PATTERN

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,11 +575,11 @@ __NOTE__: If you do change this, you'll also need to update the rswag_api.rb ini
 
 ### Input Location for Rspec Tests ###
 
-By default, rswag will search for integration tests in _spec/requests_, _spec/api_ and _spec/integration_. If you want to use tests from other locations, provide the PATTERN argument to rake:
+By default, rswag will search for integration tests in _spec/requests_, _spec/api_ and _spec/integration_. If you want to use tests from other locations, provide the RSWAG_PATTERN argument to rake:
 
 ```ruby
 # search for tests in spec/swagger
-rake rswag:specs:swaggerize PATTERN="spec/swagger/**/*_spec.rb"
+rake rswag:specs:swaggerize RSWAG_PATTERN="spec/swagger/**/*_spec.rb"
 ```
 
 ### Additional rspec options

--- a/rswag-specs/lib/tasks/rswag-specs_tasks.rake
+++ b/rswag-specs/lib/tasks/rswag-specs_tasks.rake
@@ -7,7 +7,7 @@ namespace :rswag do
     desc 'Generate Swagger JSON files from integration specs'
     RSpec::Core::RakeTask.new('swaggerize') do |t|
       t.pattern = ENV.fetch(
-        'PATTERN',
+        'RSWAG_PATTERN',
         'spec/requests/**/*_spec.rb, spec/api/**/*_spec.rb, spec/integration/**/*_spec.rb'
       )
 


### PR DESCRIPTION
## Problem

Following the last renames in this project #702, 
we should also namespace ENVs.

## Solution

Rename ENV PATTERN to RSWAG_PATTERN

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [x] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)


