### PR TITLE
Define extra options for properties 

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,15 +255,18 @@ response '200', 'blog found' do
   end
 end
 ```
+### Schema validations
 
-### Strict schema validation
-
-By default, if response body contains undocumented properties tests will pass. To keep your responses clean and validate against a strict schema definition you can set the global config option:
+#### Strict (deprecated)
+It validates required properties and disallows additional properties in response body.
+To enable, you can set the option `openapi_strict_schema_validation` to true.
+It is equal to `openapi_no_additional_properties: true` and `openapi_all_properties_required: true`
+**Important** If you would like to keep validation of required properties but allow additional properties, you can set the `openapi_strict_schema_validation` option to `false` and set `openapi_all_properties_required` to `true` and `openapi_no_additional_properties` to `false`.
 
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.openapi_strict_schema_validation = true
+  config.openapi_strict_schema_validation = true # default false
 end
 ```
 
@@ -319,6 +322,31 @@ describe 'Blogs API' do
   end
 end
 ```
+
+#### Additional properties
+If you want to disallow additional properties in response body, you can set the option `openapi_no_additional_properties` to true:
+
+```ruby
+# spec/swagger_helper.rb
+RSpec.configure do |config|
+  config.openapi_no_additional_properties = true # default false
+end
+```
+
+You can set similarly the option per individual example as shown in Strict (deprecated) sections.
+
+#### All required properties
+If you want to disallow missing required properties in response body, you can set the `openapi_all_properties_required` option to true:
+**Important** it will allow the additional properties
+
+```ruby
+# spec/swagger_helper.rb
+RSpec.configure do |config|
+  config.openapi_all_properties_required = true # default false
+end
+```
+
+You can set similarly the option per individual example as shown in Strict (deprecated) sections.
 
 ### Null Values ###
 
@@ -455,7 +483,7 @@ By default, the swagger docs are generated in JSON format. If you want to genera
 # spec/swagger_helper.rb
 RSpec.configure do |config|
   config.openapi_root = Rails.root.to_s + '/swagger'
-  
+
   # Use if you want to see which test is running
   # config.formatter = :documentation
 

--- a/rswag-specs/lib/rswag/specs.rb
+++ b/rswag-specs/lib/rswag/specs.rb
@@ -24,6 +24,8 @@ module Rswag
       c.add_setting :rswag_dry_run
       c.add_setting :openapi_format, default: :json
       c.add_setting :openapi_strict_schema_validation
+      c.add_setting :openapi_all_properties_required
+      c.add_setting :openapi_no_additional_properties
       c.extend ExampleGroupHelpers, type: :request
       c.include ExampleHelpers, type: :request
     end

--- a/rswag-specs/lib/rswag/specs/configuration.rb
+++ b/rswag-specs/lib/rswag/specs/configuration.rb
@@ -61,6 +61,14 @@ module Rswag
       def openapi_strict_schema_validation
         @rspec_config.openapi_strict_schema_validation || false
       end
+
+      def openapi_all_properties_required
+        @rspec_config.openapi_all_properties_required || false
+      end
+
+      def openapi_no_additional_properties
+        @rspec_config.openapi_no_additional_properties || false
+      end
     end
 
     class ConfigurationError < StandardError; end

--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -74,13 +74,21 @@ module Rswag
 
       def validation_options_from(metadata)
         if metadata.key?(:swagger_strict_schema_validation)
-          Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: This option will be renamed to "openapi_strict_schema_validation" in v3.0')
+          Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: This option will be removed in v3.0 please use openapi_all_properties_required and openapi_no_additional_properties set to true')
           is_strict = !!metadata[:swagger_strict_schema_validation]
         else
+          Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: This option will be removed in v3.0 please use openapi_all_properties_required and openapi_no_additional_properties set to true')
           is_strict = !!metadata.fetch(:openapi_strict_schema_validation, @config.openapi_strict_schema_validation)
         end
 
-        { strict: is_strict }
+        allPropertiesRequired = metadata.fetch(:openapi_all_properties_required, @config.openapi_all_properties_required)
+        noAdditionalProperties = metadata.fetch(:openapi_no_additional_properties, @config.openapi_no_additional_properties)
+
+        {
+          strict: is_strict,
+          allPropertiesRequired: allPropertiesRequired,
+          noAdditionalProperties: noAdditionalProperties
+        }
       end
 
       def definitions_or_component_schemas(swagger_doc, version)

--- a/rswag-specs/spec/rswag/specs/configuration_spec.rb
+++ b/rswag-specs/spec/rswag/specs/configuration_spec.rb
@@ -7,8 +7,13 @@ RSpec.describe Rswag::Specs::Configuration do
   subject { described_class.new(rspec_config) }
 
   let(:rspec_config) do
-    OpenStruct.new(openapi_root: openapi_root, openapi_specs: openapi_specs, openapi_format: openapi_format,
-                   rswag_dry_run: rswag_dry_run, openapi_strict_schema_validation: openapi_strict_schema_validation)
+    OpenStruct.new(
+      openapi_root: openapi_root, openapi_specs: openapi_specs,
+      openapi_format: openapi_format, rswag_dry_run: rswag_dry_run,
+      openapi_strict_schema_validation: openapi_strict_schema_validation,
+      openapi_all_properties_required: openapi_all_properties_required,
+      openapi_no_additional_properties: openapi_no_additional_properties
+    )
   end
   let(:openapi_root) { 'foobar' }
   let(:openapi_specs) do
@@ -20,6 +25,8 @@ RSpec.describe Rswag::Specs::Configuration do
   let(:openapi_format) { :yaml }
   let(:rswag_dry_run) { nil }
   let(:openapi_strict_schema_validation) { nil }
+  let(:openapi_all_properties_required) { nil }
+  let(:openapi_no_additional_properties) { nil }
 
   describe '#openapi_root' do
     let(:response) { subject.openapi_root }
@@ -186,6 +193,34 @@ RSpec.describe Rswag::Specs::Configuration do
 
     context 'when provided in rspec config' do
       let(:openapi_strict_schema_validation) { true }
+      it { expect(response).to eq(true) }
+    end
+  end
+
+  describe '#openapi_all_properties_required' do
+    let(:response) { subject.openapi_all_properties_required }
+
+    context 'when not provided' do
+      let(:openapi_all_properties_required) { nil }
+      it { expect(response).to eq(false) }
+    end
+
+    context 'when provided in rspec config' do
+      let(:openapi_all_properties_required) { true }
+       it { expect(response).to eq(true) }
+    end
+  end
+
+  describe '#openapi_no_additional_properties' do
+    let(:response) { subject.openapi_no_additional_properties }
+
+    context 'when not provided' do
+      let(:openapi_no_additional_properties) { nil }
+      it { expect(response).to eq(false) }
+    end
+
+    context 'when provided in rspec config' do
+      let(:openapi_no_additional_properties) { true }
       it { expect(response).to eq(true) }
     end
   end

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -11,12 +11,27 @@ module Rswag
         allow(config).to receive(:get_openapi_spec).and_return(openapi_spec)
         allow(config).to receive(:get_openapi_spec_version).and_return('2.0')
         allow(config).to receive(:openapi_strict_schema_validation).and_return(openapi_strict_schema_validation)
+        allow(config).to receive(:openapi_all_properties_required).and_return(openapi_all_properties_required)
+        allow(config).to receive(:openapi_no_additional_properties).and_return(openapi_no_additional_properties)
       end
 
       let(:config) { double('config') }
       let(:openapi_spec) { {} }
       let(:example) { double('example') }
       let(:openapi_strict_schema_validation) { false }
+      let(:openapi_all_properties_required) { false }
+      let(:openapi_no_additional_properties) { false }
+      let(:schema) do
+        {
+          type: :object,
+          properties: {
+            text: { type: :string },
+            number: { type: :integer }
+          },
+          required: ['text', 'number']
+        }
+      end
+
       let(:metadata) do
         {
           response: {
@@ -36,14 +51,7 @@ module Rswag
                 }
               }
             },
-            schema: {
-              type: :object,
-              properties: {
-                text: { type: :string },
-                number: { type: :integer }
-              },
-              required: ['text', 'number']
-            }
+            schema: { **schema }
           }
         }
       end
@@ -112,6 +120,202 @@ module Rswag
           it { expect { call }.to raise_error(/Expected response body/) }
         end
 
+        context "when response body does not have additional properties and missing properties" do
+          context "with strict schema validation enabled" do
+            let(:openapi_strict_schema_validation) { true }
+
+            before do
+              allow(Rswag::Specs.deprecator).to receive(:warn)
+            end
+
+            it { expect { call }.not_to raise_error }
+
+            it do
+              call
+
+              expect(Rswag::Specs.deprecator)
+                .to have_received(:warn).with('Rswag::Specs: WARNING: This option will be removed in v3.0' \
+                                              ' please use openapi_all_properties_required' \
+                                              ' and openapi_no_additional_properties set to true')
+            end
+          end
+
+          context "with strict schema validation disabled" do
+            let(:openapi_strict_schema_validation) { false }
+
+            before do
+              allow(Rswag::Specs.deprecator).to receive(:warn)
+            end
+
+            it { expect { call }.not_to raise_error }
+
+            it do
+              call
+
+              expect(Rswag::Specs.deprecator)
+                .to have_received(:warn).with('Rswag::Specs: WARNING: This option will be removed in v3.0' \
+                                              ' please use openapi_all_properties_required' \
+                                              ' and openapi_no_additional_properties set to true')
+            end
+          end
+
+          context "with strict schema validation disabled in config but enabled in metadata" do
+            let(:openapi_strict_schema_validation) { false }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with strict schema validation enabled in config but disabled in metadata" do
+            let(:openapi_strict_schema_validation) { true }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with all properties required disabled in config but enabled in metadata" do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with all properties required enabled in config but disabled in metadata" do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with no additional properties validation disabled in config but enabled in metadata" do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with no additional properties validation enabled in config but disabled in metadata" do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'when schema does not have required property' do
+            let(:schema) do
+              {
+                type: :object,
+                properties: {
+                  text: { type: :string },
+                  number: { type: :integer }
+                }
+              }
+            end
+
+            context "with strict schema validation enabled" do
+              let(:openapi_strict_schema_validation) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with strict schema validation disabled" do
+              let(:openapi_strict_schema_validation) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with strict schema validation disabled in config but enabled in metadata" do
+              let(:openapi_strict_schema_validation) { false }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with strict schema validation enabled in config but disabled in metadata" do
+              let(:openapi_strict_schema_validation) { true }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled' do
+              let(:openapi_all_properties_required) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required disabled' do
+              let(:openapi_all_properties_required) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with all properties required disabled in config but enabled in metadata" do
+              let(:openapi_all_properties_required) { false }
+              let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with all properties required enabled in config but disabled in metadata" do
+              let(:openapi_all_properties_required) { true }
+              let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties enabled' do
+              let(:openapi_no_additional_properties) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties disabled' do
+              let(:openapi_no_additional_properties) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with no additional properties validation disabled in config but enabled in metadata" do
+              let(:openapi_no_additional_properties) { false }
+              let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with no additional properties validation enabled in config but disabled in metadata" do
+              let(:openapi_no_additional_properties) { true }
+              let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+          end
+        end
+
         context "when response body has additional properties" do
           before { response.body = '{"foo":"Some comment", "number": 3, "text":"bar"}' }
 
@@ -139,6 +343,402 @@ module Rswag
             let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
 
             it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with all properties required disabled in config but enabled in metadata" do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with all properties required enabled in config but disabled in metadata" do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context "with no additional properties validation disabled in config but enabled in metadata" do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with no additional properties validation enabled in config but disabled in metadata" do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'when schema does not have required property' do
+            let(:schema) do
+              {
+                type: :object,
+                properties: {
+                  text: { type: :string },
+                  number: { type: :integer }
+                }
+              }
+            end
+
+            context "with strict schema validation enabled" do
+              let(:openapi_strict_schema_validation) { true }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context "with strict schema validation disabled" do
+              let(:openapi_strict_schema_validation) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with strict schema validation disabled in config but enabled in metadata" do
+              let(:openapi_strict_schema_validation) { false }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context "with strict schema validation enabled in config but disabled in metadata" do
+              let(:openapi_strict_schema_validation) { true }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled' do
+              let(:openapi_all_properties_required) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required disabled' do
+              let(:openapi_all_properties_required) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with all properties required disabled in config but enabled in metadata" do
+              let(:openapi_all_properties_required) { false }
+              let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with all properties required enabled in config but disabled in metadata" do
+              let(:openapi_all_properties_required) { true }
+              let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties enabled' do
+              let(:openapi_no_additional_properties) { true }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context 'with no additional properties disabled' do
+              let(:openapi_no_additional_properties) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with no additional properties validation disabled in config but enabled in metadata" do
+              let(:openapi_no_additional_properties) { false }
+              let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context "with no additional properties validation enabled in config but disabled in metadata" do
+              let(:openapi_no_additional_properties) { true }
+              let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+          end
+        end
+
+        context "when response body has missing properties" do
+          before { response.body = '{"number": 3}' }
+
+          context "with strict schema validation enabled" do
+            let(:openapi_strict_schema_validation) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation disabled" do
+            let(:openapi_strict_schema_validation) { false }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation disabled in config but enabled in metadata" do
+            let(:openapi_strict_schema_validation) { false }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation enabled in config but disabled in metadata" do
+            let(:openapi_strict_schema_validation) { true }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with all properties required disabled in config but enabled in metadata" do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with all properties required enabled in config but disabled in metadata" do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with no additional properties validation disabled in config but enabled in metadata" do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with no additional properties validation enabled in config but disabled in metadata" do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+        end
+
+        context "when response body has missing properties and additional properties" do
+          before { response.body = '{"foo":"Some comment", "text":"bar"}' }
+
+          context "with strict schema validation enabled" do
+            let(:openapi_strict_schema_validation) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation disabled" do
+            let(:openapi_strict_schema_validation) { false }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation disabled in config but enabled in metadata" do
+            let(:openapi_strict_schema_validation) { false }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with strict schema validation enabled in config but disabled in metadata" do
+            let(:openapi_strict_schema_validation) { true }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with all properties required disabled in config but enabled in metadata" do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with all properties required enabled in config but disabled in metadata" do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with no additional properties validation disabled in config but enabled in metadata" do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context "with no additional properties validation enabled in config but disabled in metadata" do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.to raise_error /Expected response body/ }
+          end
+
+          context 'when schema does not have required property' do
+            let(:schema) do
+              {
+                type: :object,
+                properties: {
+                  text: { type: :string },
+                  number: { type: :integer }
+                }
+              }
+            end
+
+            context "with strict schema validation enabled" do
+              let(:openapi_strict_schema_validation) { true }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context "with strict schema validation disabled" do
+              let(:openapi_strict_schema_validation) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with strict schema validation disabled in config but enabled in metadata" do
+              let(:openapi_strict_schema_validation) { false }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context "with strict schema validation enabled in config but disabled in metadata" do
+              let(:openapi_strict_schema_validation) { true }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled' do
+              let(:openapi_all_properties_required) { true }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context 'with all properties required disabled' do
+              let(:openapi_all_properties_required) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with all properties required disabled in config but enabled in metadata" do
+              let(:openapi_all_properties_required) { false }
+              let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context "with all properties required enabled in config but disabled in metadata" do
+              let(:openapi_all_properties_required) { true }
+              let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties enabled' do
+              let(:openapi_no_additional_properties) { true }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context 'with no additional properties disabled' do
+              let(:openapi_no_additional_properties) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context "with no additional properties validation disabled in config but enabled in metadata" do
+              let(:openapi_no_additional_properties) { false }
+              let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+              it { expect { call }.to raise_error /Expected response body/ }
+            end
+
+            context "with no additional properties validation enabled in config but disabled in metadata" do
+              let(:openapi_no_additional_properties) { true }
+              let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
           end
         end
 

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -149,6 +149,14 @@ RSpec.describe 'Blogs API', type: :request, openapi_spec: 'v1/swagger.json' do
         context 'when openapi_strict_schema_validation is true' do
           run_test!(openapi_strict_schema_validation: true)
         end
+
+        context 'when openapi_all_properties_required is true' do
+          run_test!(openapi_all_properties_required: true)
+        end
+
+        context 'when openapi_no_additional_properties is true' do
+          run_test!(openapi_no_additional_properties: true)
+        end
       end
 
       response '404', 'blog not found' do
@@ -157,6 +165,30 @@ RSpec.describe 'Blogs API', type: :request, openapi_spec: 'v1/swagger.json' do
       end
 
       response '200', 'blog found - openapi_strict_schema_validation = true', openapi_strict_schema_validation: true do
+        schema '$ref' => '#/components/schemas/blog'
+
+        let(:id) { blog.id }
+
+        run_test!
+      end
+
+      response '200', 'blog found - openapi_all_properties_required = true', openapi_all_properties_required: true do
+        schema '$ref' => '#/components/schemas/blog'
+
+        let(:id) { blog.id }
+
+        run_test!
+      end
+
+      response '200', 'blog found - openapi_all_properties_required = true', openapi_all_properties_required: true do
+        schema '$ref' => '#/components/schemas/blog'
+
+        let(:id) { blog.id }
+
+        run_test!
+      end
+
+      response '200', 'blog found - openapi_no_additional_properties = true', openapi_no_additional_properties: true do
         schema '$ref' => '#/components/schemas/blog'
 
         let(:id) { blog.id }

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -227,7 +227,7 @@
         "operationId": "getBlog",
         "responses": {
           "200": {
-            "description": "blog found - openapi_strict_schema_validation = true",
+            "description": "blog found - openapi_no_additional_properties = true",
             "headers": {
               "ETag": {
                 "type": "string"


### PR DESCRIPTION
## Problem
It closes https://github.com/rswag/rswag/issues/666

## Solution
Added two more options to allow to use `allPropertiesRequired` and `noAdditionalProperties` options from [json-schema](https://github.com/a-lavis/json-schema)

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
