### PR TITLE
fix: rubygems-update version for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV RAILS_VERSION 7.0.3.1
 
 RUN apt-get update -qq && apt-get install -y nodejs npm
 # Bugfix for https://github.com/rubyjs/mini_racer/issues/220#issuecomment-1010724771
-RUN gem update --system 3.4.2
+RUN gem update --system 3.4.22
 
 # Run docker as a non-root user to avoid having to chown generated files while developing
 ENV APP_PATH=/rswag/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV RAILS_VERSION 7.0.3.1
 
 RUN apt-get update -qq && apt-get install -y nodejs npm
 # Bugfix for https://github.com/rubyjs/mini_racer/issues/220#issuecomment-1010724771
-RUN gem update --system
+RUN gem update --system 3.4.2
 
 # Run docker as a non-root user to avoid having to chown generated files while developing
 ENV APP_PATH=/rswag/


### PR DESCRIPTION
## Problem
rubygems-update version grater than 3.5 required ruby version grater than 3.0.0.
https://rubygems.org/gems/rubygems-update/versions/3.5.0

```
 > [test-app 3/8] RUN gem update --system:
11.63 ERROR:  Error installing rubygems-update:
11.63   There are no versions of rubygems-update (= 3.5.5) compatible with your Ruby & RubyGems
11.63   rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
11.63 ERROR:  While executing gem ... (NoMethodError)
11.63     undefined method `version' for nil:NilClass
11.65 Updating rubygems-update
```

## Solution
Fix rubygems-update version for Docker ruby 2.7.
https://rubygems.org/gems/rubygems-update/versions/3.4.22

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
