### PR TITLE
fix: encode query params when use schema type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Allow vendor-specific MIME types for JSON payloads (https://github.com/rswag/rswag/pull/769)
+- Fix escaping of schema in path parameters for openapi spec >= 3.0.0 (https://github.com/rswag/rswag/pull/725)
 
 ## [2.14.0] - 2024-08-13
 

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -174,7 +174,7 @@ module Rswag
               return "#{escaped_name}=" + value.to_a.flatten.map{|v| CGI.escape(v.to_s) }.join(separator)
             end
           else
-            return "#{name}=#{value}"
+            return "#{escaped_name}=#{CGI.escape(value.to_s)}"
           end
         end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -169,6 +169,20 @@ module Rswag
               expect(request[:path]).to eq('/blogs?date_time=2001-02-03T04%3A05%3A06-07%3A00')
             end
           end
+
+          context 'openapi spec >= 3.0.0' do
+            let(:openapi_spec) { { swagger: '3.0' } }
+            before do
+              allow(example).to receive(:date_time).and_return(date_time)
+            end
+
+            it 'formats the datetime properly when type is defined in schema' do
+              metadata[:operation][:parameters] = [
+                { name: 'date_time', in: :query, schema: { type: :string }, format: :datetime, }
+              ]
+              expect(request[:path]).to eq('/blogs?date_time=2001-02-03T04%3A05%3A06-07%3A00')
+            end
+          end
         end
 
         context "'query' parameters of type 'object'" do


### PR DESCRIPTION
## Problem
When use `schema: { type: : string }` with openAPI 3, it does not encode.
Then it causes
```
Failure/Error: raise InvalidURIError, "URI must be ascii only #{uri.dump}"
```

`rspec -format Rswag::Specs::SwaggerFormatter` overrides metadata `type` to `schema: { type: :xxx}` 
https://github.com/rswag/rswag/blob/1058fde6e7a89388f866f1c2e64c81b4e7615975/rswag-specs/lib/rswag/specs/swagger_formatter.rb#L158-L162

## Solution
encode query parameter when using oepnAPI version 3 with  schema type.

extends https://github.com/rswag/rswag/pull/621



### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [ ] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
