### PR TITLE
fix: rubygems-update for github actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,7 +43,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        gem update --system
+        if [ ${{ matrix.ruby }} < 3 ]; then
+          gem update --system 3.4.22
+        else
+          gem update --system
+        fi
         bundle install
         cd rswag-ui && npm install
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        if [ ${{ matrix.ruby }} < 3 ]; then
+        if [ $(cut -d '.' -f 1 <<< "${{ matrix.ruby }}") -lt 3 ]; then
           gem update --system 3.4.22
         else
           gem update --system


### PR DESCRIPTION
## Problem
GitHub Actions Ruby2.x is not working.

## Solution
set rubygems-update version

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
