### PR TITLE
Return integer status in Rswag API middleware

### DIFF
--- a/rswag-api/lib/rswag/api/middleware.rb
+++ b/rswag-api/lib/rswag/api/middleware.rb
@@ -26,7 +26,7 @@ module Rswag
           body = unload_swagger(filename, swagger)
 
           return [
-            '200',
+            200,
             headers,
             [body]
           ]

--- a/rswag-api/spec/rswag/api/middleware_spec.rb
+++ b/rswag-api/spec/rswag/api/middleware_spec.rb
@@ -28,7 +28,7 @@ describe Rswag::Api::Middleware do
 
       it 'returns a 200 status' do
         expect(response.length).to eql(3)
-        expect(response.first).to eql('200')
+        expect(response.first).to eql(200)
       end
 
       it 'returns contents of the swagger file' do
@@ -44,7 +44,7 @@ describe Rswag::Api::Middleware do
 
         it 'returns a 200 status' do
           expect(response.length).to eql(3)
-          expect(response.first).to eql('200')
+          expect(response.first).to eql(200)
         end
       end
     end
@@ -58,7 +58,7 @@ describe Rswag::Api::Middleware do
         end
         it 'returns a 200 status' do
           expect(response.length).to eql(3)
-          expect(response.first).to eql('200')
+          expect(response.first).to eql(200)
         end
 
         it 'applies the headers to the response' do
@@ -72,7 +72,7 @@ describe Rswag::Api::Middleware do
         end
         it 'returns a 200 status' do
           expect(response.length).to eql(3)
-          expect(response.first).to eql('200')
+          expect(response.first).to eql(200)
         end
 
         it 'applies the headers to the response' do
@@ -167,7 +167,7 @@ describe Rswag::Api::Middleware do
 
       it 'returns a 200 status' do
         expect(response.length).to eql(3)
-        expect(response.first).to eql('200')
+        expect(response.first).to eql(200)
       end
 
       it 'returns contents of the swagger file' do


### PR DESCRIPTION
## Problem
Rswag API middleware doesn't work with [socketry/falcon](https://github.com/socketry/falcon) webserver. 
HTTP status must be integer [socketry/protocol-rack](https://github.com/socketry/protocol-rack/blob/5862e7f9fab3f8ebb5fe9622bfec6eb120cb0800/lib/protocol/rack/adapter/generic.rb#L111).

## Solution
Return integer status instead of string.

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)
