### PR TITLE
Add support for OAS 3.0 oneOf discriminators

### DIFF
--- a/rswag-specs/lib/rswag/specs/extended_schema.rb
+++ b/rswag-specs/lib/rswag/specs/extended_schema.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'json-schema'
+require 'rswag/specs/openapi_oneof'
 
 module Rswag
   module Specs
     class ExtendedSchema < JSON::Schema::Draft4
       def initialize
         super
+        @attributes['oneOf'] = OpenAPIOneOfAttribute
         @uri = URI.parse('http://tempuri.org/rswag/specs/extended_schema')
         @names = ['http://tempuri.org/rswag/specs/extended_schema']
       end

--- a/rswag-specs/lib/rswag/specs/openapi_oneof.rb
+++ b/rswag-specs/lib/rswag/specs/openapi_oneof.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'json-schema'
+
+class OpenAPIOneOfAttribute < JSON::Schema::OneOfAttribute
+  def self.validate(current_schema, data, fragments, processor, validator, options = {})
+    return super unless current_schema.schema.key?('discriminator')
+
+    discriminator = current_schema.schema['discriminator']
+    prop_name = discriminator['propertyName']
+
+    unless data.key?(prop_name)
+      message = "The response payload must contain a property with name #{prop_name}"
+      validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+      return
+    end
+
+    discriminator_value = data[prop_name]
+    schema_ref = if discriminator['mapping']&.key?(discriminator_value)
+      # Explicit schema matching using the ref specified by the discriminator mapping.
+      schema_mapping = discriminator['mapping'][discriminator_value]
+      current_schema.schema['oneOf'].find { |e| e['$ref'] == schema_mapping }
+    else
+      # Implicit schema matching using the discriminator value from the response data as schema name.
+      { "$ref" => "#/components/schemas/#{discriminator_value}" }
+    end
+
+    unless schema_ref
+      message = "The discriminator value #{discriminator_value} did not match any of the required schemas"
+      validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+      return
+    end
+
+    original_data = data.is_a?(Hash) ? data.clone : data
+    schema = JSON::Schema.new(schema_ref, current_schema.uri, validator)
+
+    begin
+      schema.validate(data, fragments, processor, options)
+    rescue JSON::Schema::ValidationError
+      data = original_data
+      message = "The property '#{build_fragment(fragments)}' of type #{type_of_data(data)} did not match the required schema #{schema_ref}"
+      validation_error(processor, message, fragments, current_schema, select, options[:record_errors])
+    end
+  end
+end


### PR DESCRIPTION
## Problem
When adding an OpenAPI Discriminator Object to my response schema, rswag doesn't use it to disambiguate between similar schemas specified inside of a `oneOf`. This makes it impossible to express multiple schemas that are potentially ambiguous to the validator.

## Solution
Implement support for using a Discriminator Object (if available) to disambiguate between schemas to use for response validation.

Important: I'm not a Ruby developer by trade which means that this code likely can be improved by someone who knows what they're doing 😅  Any and all suggestions are welcome! I'd love to learn more about this. I've opted not to update the changelog or add documentation yet since I'd like to get feedback on the implementation first.

### This concerns this parts of the OpenAPI Specification:
* [Discriminator Object](https://spec.openapis.org/oas/v3.1.0#discriminator-object)

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
I've added test cases to validate that the library now uses the discriminator object.
