### PR TITLE
Update generated rswag_ui.rb to use openapi_endpoint.

### DIFF
--- a/rswag-ui/lib/generators/rswag/ui/install/templates/rswag_ui.rb
+++ b/rswag-ui/lib/generators/rswag/ui/install/templates/rswag_ui.rb
@@ -8,7 +8,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  c.openapi_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true


### PR DESCRIPTION
## Problem
Recently I have created new app and installed RSwag and it emits deprecation warning by default.

## Solution
Change template for generated `rswag_ui.rb` initializer to use `openapi_endpoint` instead of deprecated `swagger_endpoint`.

### Checklist
- [ ] Added tests (there is no test related per my understanding)
- [ ] Changelog updated (should I add entry?)

### Steps to Test or Reproduce
Run `rails g rswag:install` in new app.
