### PR TITLE
WIP fix: remove 'getter' from generated swagger file

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -117,7 +117,7 @@ module Rswag
         operation = metadata[:operation]
           .reject { |k, _v| k == :verb }
           .merge(responses: { response_code => response })
-
+        metadata[:operation][:parameters]&.each{|hash| hash.delete(:getter) }
         path_template = metadata[:path_item][:template]
         path_item = metadata[:path_item]
           .reject { |k, _v| k == :template }


### PR DESCRIPTION
## Problem
On swaggerize, generated swagger file is no longer correct. 

## Solution
Remove key from operation parameters 

### This concerns this parts of the OpenAPI Specification:
N/A

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [ ] OAS3.1

### Related Issues

#747

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
