### PR TITLE
fix: Allow vendor-specific MIME types for JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Allow vendor-specific MIME types for JSON payloads (https://github.com/rswag/rswag/pull/769)
+
 ## [2.14.0] - 2024-08-13
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ case rails_version.split('.').first
 when '5'
   gem 'sqlite3', '~> 1.3.6'
 when  '6', '7'
-  gem 'sqlite3', '~> 1.4.1'
+  gem 'sqlite3', '~> 1.4'
 end
 
 case RUBY_VERSION.split('.').first
@@ -45,7 +45,6 @@ group :development do
 end
 
 group :assets do
-  gem 'mini_racer'
   gem 'uglifier'
 end
 

--- a/cspell.json
+++ b/cspell.json
@@ -42,6 +42,7 @@
     "rdoc",
     "rdoctask",
     "rswag",
+    "rubygems",
     "srand",
     "scrollbars",
     "stylesheet",

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -244,7 +244,7 @@ module Rswag
 
         request[:payload] = if ['application/x-www-form-urlencoded', 'multipart/form-data'].include?(content_type)
                               build_form_payload(parameters, example)
-                            elsif content_type == 'application/json'
+                            elsif content_type =~ /\Aapplication\/(vnd\..+\+)?json\z/
                               build_json_payload(parameters, example)
                             else
                               build_raw_payload(parameters, example)

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -378,6 +378,18 @@ module Rswag
             end
           end
 
+          context 'JSON:API payload' do
+            before do
+              metadata[:operation][:consumes] = 'application/vnd.api+json'
+              metadata[:operation][:parameters] = [{ name: 'comment', in: :body, schema: { type: 'object' } }]
+              allow(example).to receive(:comment).and_return(text: 'Some comment')
+            end
+
+            it "serializes first 'body' parameter to JSON object" do
+              expect(request[:payload]).to eq(text: 'Some comment')
+            end
+          end
+
           context 'missing body parameter' do
             before do
               metadata[:operation][:parameters] = [{ name: 'comment', in: :body, schema: { type: 'object' } }]


### PR DESCRIPTION
## Problem
#639 added a bug that does not encode vendor-specific MIME types such as `application/vnd.api+json` as JSON payloads.

## Solution
Use a regular expression instead of the default `application/json` to detect JSON payloads.

### This concerns this parts of the OpenAPI Specification:
* [Media Types](https://spec.openapis.org/oas/v3.1.0#media-types)
### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)
