### PR TITLE
Remove deprecation warning on fresh install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Change the method `swagger_endpoint` to `openapi_endpoint` on fresh install.
+
 ## [2.14.0] - 2024-08-13
 
 ### Added

--- a/rswag-ui/lib/generators/rswag/ui/install/templates/rswag_ui.rb
+++ b/rswag-ui/lib/generators/rswag/ui/install/templates/rswag_ui.rb
@@ -8,7 +8,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  c.openapi_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true


### PR DESCRIPTION
## Problem

The method `swagger_endpoint` has been deprecated in favor of `openapi_endpoint`, see: https://github.com/rswag/rswag/blob/master/rswag-ui/lib/rswag/ui/configuration.rb#L28

## Solution
On fresh install, the old method is still used in template, this PR fixes it

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Checklist
- [ ] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
