### PR TITLE
chore: loosen json-schema dependency again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Relaxed the dependency on json-schema to make v5 available.
+
 ### Fixed
 
 ## [2.14.0] - 2024-08-13

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
   s.add_dependency 'activesupport', '>= 5.2', '< 8.0'
-  s.add_dependency 'json-schema', '>= 2.2', '< 5.0'
+  s.add_dependency 'json-schema', '>= 2.2', '< 6.0'
   s.add_dependency 'railties', '>= 5.2', '< 8.0'
   s.add_dependency 'rspec-core', '>=2.14'
 


### PR DESCRIPTION
## Problem
`json-schema` v5 has been released and once again the gem limits the usage of this version.


## Solution
Loosen the available library versions. The [changelog](https://github.com/voxpupuli/json-schema/blob/master/CHANGELOG.md) doesn't point to any part used in this gem so upgrade should be seamless.


### Checklist
- [x] Changelog updated

see also my previous Issue https://github.com/rswag/rswag/issues/669 and the related PR https://github.com/rswag/rswag/pull/659 