### PR TITLE
fix: adjust regex to match Media Types with JSON content

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -244,7 +244,7 @@ module Rswag
 
         request[:payload] = if ['application/x-www-form-urlencoded', 'multipart/form-data'].include?(content_type)
                               build_form_payload(parameters, example)
-                            elsif content_type =~ /\Aapplication\/(vnd\..+\+)?json\z/
+                            elsif content_type =~ /\Aapplication\/([0-9A-Za-z._-]+\+json\z|json\z)/
                               build_json_payload(parameters, example)
                             else
                               build_raw_payload(parameters, example)


### PR DESCRIPTION
## Problem
https://github.com/rswag/rswag/issues/779

## Solution

Adjusting regex to match [registered Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml) with `+json` suffix or `application/json`

### This concerns this parts of the OpenAPI Specification:
* [Media Types](https://spec.openapis.org/oas/v3.1.0#media-types)

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce

See https://github.com/rswag/rswag/issues/779
