### PR TITLE
Fix rubocop offense Style/StringConcatenation for some templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ In addition to paths, operations and responses, Swagger also supports global API
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.openapi_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.join('swagger').to_s
 
   config.openapi_specs = {
     'v1/swagger.json' => {
@@ -496,7 +496,7 @@ By default, the swagger docs are generated in JSON format. If you want to genera
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.openapi_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.join('swagger').to_s
 
   # Use if you want to see which test is running
   # config.formatter = :documentation
@@ -555,7 +555,7 @@ Swagger supports :basic, :bearer, :apiKey and :oauth2 and :openIdConnect scheme 
 ```ruby
 # spec/swagger_helper.rb
 RSpec.configure do |config|
-  config.openapi_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.join('swagger').to_s
 
   config.openapi_specs = {
     'v1/swagger.json' => {

--- a/rswag-api/lib/generators/rswag/api/install/templates/rswag_api.rb
+++ b/rswag-api/lib/generators/rswag/api/install/templates/rswag_api.rb
@@ -4,7 +4,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.openapi_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.join('swagger').to_s
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/test-app/config/initializers/rswag-api.rb
+++ b/test-app/config/initializers/rswag-api.rb
@@ -4,7 +4,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.openapi_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.join('swagger').to_s
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/test-app/spec/rake/rswag_specs_swaggerize_spec.rb
+++ b/test-app/spec/rake/rswag_specs_swaggerize_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rake'
 
 RSpec.describe 'rswag:specs:swaggerize' do
-  let(:openapi_root) { Rails.root.to_s + '/swagger' }
+  let(:openapi_root) { Rails.root.join('swagger').to_s }
 
   before do
     TestApp::Application.load_tasks

--- a/test-app/spec/swagger_helper.rb
+++ b/test-app/spec/swagger_helper.rb
@@ -6,7 +6,7 @@ RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.openapi_root = Rails.root.to_s + '/swagger'
+  config.openapi_root = Rails.root.join('swagger').to_s
   config.rswag_dry_run = false
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:to_swagger' rake task, the complete Swagger will


### PR DESCRIPTION
## Problem
After run the install generator rswag generate file with rubocop offense `Style/StringConcatenation`

For each project after generation this needs to be corrected

```ruby
config.openapi_root = Rails.root.to_s + '/swagger'
```

## Solution
```ruby
config.openapi_root = Rails.root.join('swagger').to_s
```

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
Couldn't find any related issues

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
