### PR TITLE
fix: Suppress deprecation warning when strict setting is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Suppress deprecation warning when strict setting is not set (https://github.com/rswag/rswag/pull/785)
 - Allow vendor-specific MIME types for JSON payloads (https://github.com/rswag/rswag/pull/769)
 - Fix escaping of schema in path parameters for openapi spec >= 3.0.0 (https://github.com/rswag/rswag/pull/725)
 

--- a/rswag-specs/lib/rswag/specs.rb
+++ b/rswag-specs/lib/rswag/specs.rb
@@ -12,8 +12,7 @@ module Rswag
       swagger_root: :openapi_root,
       swagger_docs: :openapi_specs,
       swagger_dry_run: :rswag_dry_run,
-      swagger_format: :openapi_format,
-      swagger_strict_schema_validation: :openapi_strict_schema_validation
+      swagger_format: :openapi_format
     }.freeze
     private_constant :RENAMED_METHODS
 
@@ -48,11 +47,20 @@ module Rswag
           public_send("#{new_name}=", *args, &block)
         end
       end
+
+      define_method('swagger_strict_schema_validation=') do |*args, &block|
+        public_send('openapi_strict_schema_validation=', *args, &block)
+      end
     end
 
     Specs.deprecator.deprecate_methods(
       RSpec::Core::Configuration,
       RENAMED_METHODS.to_h { |old_name, new_name| ["#{old_name}=".to_sym, "#{new_name}=".to_sym] }
+    )
+
+    Specs.deprecator.deprecate_methods(
+      RSpec::Core::Configuration,
+      :openapi_strict_schema_validation= => 'use openapi_all_properties_required and openapi_no_additional_properties set to true'
     )
 
     if RUBY_VERSION.start_with? '2.6'

--- a/rswag-specs/lib/rswag/specs/response_validator.rb
+++ b/rswag-specs/lib/rswag/specs/response_validator.rb
@@ -73,21 +73,23 @@ module Rswag
       end
 
       def validation_options_from(metadata)
+        is_strict = @config.openapi_strict_schema_validation
+
         if metadata.key?(:swagger_strict_schema_validation)
           Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: This option will be removed in v3.0 please use openapi_all_properties_required and openapi_no_additional_properties set to true')
           is_strict = !!metadata[:swagger_strict_schema_validation]
-        else
+        elsif metadata.key?(:openapi_strict_schema_validation)
           Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: This option will be removed in v3.0 please use openapi_all_properties_required and openapi_no_additional_properties set to true')
-          is_strict = !!metadata.fetch(:openapi_strict_schema_validation, @config.openapi_strict_schema_validation)
+          is_strict = !!metadata[:openapi_strict_schema_validation]
         end
 
-        allPropertiesRequired = metadata.fetch(:openapi_all_properties_required, @config.openapi_all_properties_required)
-        noAdditionalProperties = metadata.fetch(:openapi_no_additional_properties, @config.openapi_no_additional_properties)
+        all_properties_required = metadata.fetch(:openapi_all_properties_required, @config.openapi_all_properties_required)
+        no_additional_properties = metadata.fetch(:openapi_no_additional_properties, @config.openapi_no_additional_properties)
 
         {
           strict: is_strict,
-          allPropertiesRequired: allPropertiesRequired,
-          noAdditionalProperties: noAdditionalProperties
+          allPropertiesRequired: all_properties_required,
+          noAdditionalProperties: no_additional_properties
         }
       end
 

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -56,6 +56,19 @@ module Rswag
         }
       end
 
+      shared_context 'with strict deprecation warning' do
+        before do
+          allow(Rswag::Specs.deprecator).to receive(:warn)
+        end
+
+        after do
+          expect(Rswag::Specs.deprecator)
+            .to have_received(:warn).with('Rswag::Specs: WARNING: This option will be removed in v3.0' \
+                                          ' please use openapi_all_properties_required' \
+                                          ' and openapi_no_additional_properties set to true')
+        end
+      end
+
       describe '#validate!(metadata, response)' do
         let(:call) { subject.validate!(metadata, response) }
         let(:response) do
@@ -124,44 +137,20 @@ module Rswag
           context "with strict schema validation enabled" do
             let(:openapi_strict_schema_validation) { true }
 
-            before do
-              allow(Rswag::Specs.deprecator).to receive(:warn)
-            end
-
             it { expect { call }.not_to raise_error }
-
-            it do
-              call
-
-              expect(Rswag::Specs.deprecator)
-                .to have_received(:warn).with('Rswag::Specs: WARNING: This option will be removed in v3.0' \
-                                              ' please use openapi_all_properties_required' \
-                                              ' and openapi_no_additional_properties set to true')
-            end
           end
 
           context "with strict schema validation disabled" do
             let(:openapi_strict_schema_validation) { false }
 
-            before do
-              allow(Rswag::Specs.deprecator).to receive(:warn)
-            end
-
             it { expect { call }.not_to raise_error }
-
-            it do
-              call
-
-              expect(Rswag::Specs.deprecator)
-                .to have_received(:warn).with('Rswag::Specs: WARNING: This option will be removed in v3.0' \
-                                              ' please use openapi_all_properties_required' \
-                                              ' and openapi_no_additional_properties set to true')
-            end
           end
 
           context "with strict schema validation disabled in config but enabled in metadata" do
             let(:openapi_strict_schema_validation) { false }
             let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            include_context 'with strict deprecation warning'
 
             it { expect { call }.not_to raise_error }
           end
@@ -169,6 +158,8 @@ module Rswag
           context "with strict schema validation enabled in config but disabled in metadata" do
             let(:openapi_strict_schema_validation) { true }
             let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
 
             it { expect { call }.not_to raise_error }
           end
@@ -252,12 +243,16 @@ module Rswag
               let(:openapi_strict_schema_validation) { false }
               let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
 
+              include_context 'with strict deprecation warning'
+
               it { expect { call }.not_to raise_error }
             end
 
             context "with strict schema validation enabled in config but disabled in metadata" do
               let(:openapi_strict_schema_validation) { true }
               let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              include_context 'with strict deprecation warning'
 
               it { expect { call }.not_to raise_error }
             end
@@ -335,12 +330,16 @@ module Rswag
             let(:openapi_strict_schema_validation) { false }
             let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
 
+            include_context 'with strict deprecation warning'
+
             it { expect { call }.to raise_error /Expected response body/ }
           end
 
           context "with strict schema validation enabled in config but disabled in metadata" do
             let(:openapi_strict_schema_validation) { true }
             let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
 
             it { expect { call }.not_to raise_error }
           end
@@ -424,12 +423,16 @@ module Rswag
               let(:openapi_strict_schema_validation) { false }
               let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
 
+              include_context 'with strict deprecation warning'
+
               it { expect { call }.to raise_error /Expected response body/ }
             end
 
             context "with strict schema validation enabled in config but disabled in metadata" do
               let(:openapi_strict_schema_validation) { true }
               let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              include_context 'with strict deprecation warning'
 
               it { expect { call }.not_to raise_error }
             end
@@ -507,12 +510,16 @@ module Rswag
             let(:openapi_strict_schema_validation) { false }
             let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
 
+            include_context 'with strict deprecation warning'
+
             it { expect { call }.to raise_error /Expected response body/ }
           end
 
           context "with strict schema validation enabled in config but disabled in metadata" do
             let(:openapi_strict_schema_validation) { true }
             let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
 
             it { expect { call }.to raise_error /Expected response body/ }
           end
@@ -589,12 +596,16 @@ module Rswag
             let(:openapi_strict_schema_validation) { false }
             let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
 
+            include_context 'with strict deprecation warning'
+
             it { expect { call }.to raise_error /Expected response body/ }
           end
 
           context "with strict schema validation enabled in config but disabled in metadata" do
             let(:openapi_strict_schema_validation) { true }
             let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
 
             it { expect { call }.to raise_error /Expected response body/ }
           end
@@ -678,12 +689,16 @@ module Rswag
               let(:openapi_strict_schema_validation) { false }
               let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
 
+              include_context 'with strict deprecation warning'
+
               it { expect { call }.to raise_error /Expected response body/ }
             end
 
             context "with strict schema validation enabled in config but disabled in metadata" do
               let(:openapi_strict_schema_validation) { true }
               let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              include_context 'with strict deprecation warning'
 
               it { expect { call }.not_to raise_error }
             end

--- a/test-app/spec/rails_helper.rb
+++ b/test-app/spec/rails_helper.rb
@@ -25,14 +25,6 @@ require 'rspec/rails'
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  fixture_path = "#{::Rails.root}/spec/fixtures"
-  if Rails.gem_version >= Gem::Version.new('7.2')
-    config.fixture_paths = [fixture_path]
-  else
-    config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  end
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/test-app/spec/rails_helper.rb
+++ b/test-app/spec/rails_helper.rb
@@ -26,7 +26,12 @@ require 'rspec/rails'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  fixture_path = "#{::Rails.root}/spec/fixtures"
+  if Rails.gem_version >= Gem::Version.new('7.2')
+    config.fixture_paths = [fixture_path]
+  else
+    config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
## Problem
Even when the settings `swagger_strict_schema_validation` and `openapi_strict_schema_validation` are not used, deprecation warnings are issued.

## Solution
Only print deprecation warning when the deprecated settings are used.

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
