### PR TITLE
Fix encoding of path params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixed
 
+- Fix encoding of path params
+
 ## [2.15.0] - 2024-10-04
 
 ### Added

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -130,7 +130,7 @@ module Rswag
               raise ArgumentError.new("`#{p[:name].to_s}` parameter key present, but not defined within example group"\
                 "(i. e `it` or `let` block)")
             end
-            path_template.gsub!("{#{p[:name]}}", example.send(extract_getter(p)).to_s)
+            path_template.gsub!("{#{p[:name]}}", CGI.escape(example.send(extract_getter(p)).to_s))
           end
 
           parameters.select { |p| p[:in] == :query }.each_with_index do |p, i|

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -55,6 +55,16 @@ module Rswag
               expect(request[:path]).to eq('/blogs/1/comments/2')
             end
 
+            context 'when values need to be url encoded' do
+              before do
+                allow(example).to receive(:blog_id).and_return('foo:1337')
+              end
+
+              it 'url encodes the values' do
+                expect(request[:path]).to eq('/blogs/foo%3A1337/comments/2')
+              end
+            end
+
             context 'when `getter is defined`' do
               before do
                 metadata[:operation][:parameters] = [


### PR DESCRIPTION
## Problem
Using a path parameter with an url-unsafe characters, e.g. `/blogs/{blog_id}` with `foo:1337` should be encoded to `/blogs/foo%3A1337`.

## Solution
Use CGI.escape to url encode path parameters when building a spec request.

### This concerns this parts of the OpenAPI Specification:
Not applicable.

### The changes I made are compatible with:
- [X] OAS2
- [X] OAS3
- [X] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [X] Added tests
- [X] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Using a path parameter with any url-unsafe characters, e.g. `/blogs/{blog_id}` with `foo:1337`
