### PR TITLE
ci: Add support for Rails 8

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
         # Rails 5.2 became EOL on 2022-06-01; kept for information only
         # Rails 6.0 became EOL on 2023-06-01; kept for information only
-        rails: ['5.2.8.1', '6.0.6.1', '6.1.7.8', '7.0.8.4', '7.1.3.4', '7.2.0']
+        rails: ['5.2.8.1', '6.0.6.1', '6.1.7.8', '7.0.8.4', '7.1.3.4', '7.2.0', '8.0.0']
 
         exclude:
         # Excludes Rails 5.2 on Ruby 3.0+
@@ -27,6 +27,7 @@ jobs:
         # Excludes Rails 7.0 on Ruby 2.6
         # Excludes Rails 7.1 on Ruby 2.6
         # Excludes Rails 7.2 on Ruby 2.6, 2.7, 3.0
+        # Excludes Rails 8.0 on Ruby 2.6, 2.7, 3.0, 3.1
         - rails: '5.2.8.1'
           ruby: '3.0'
         - rails: '5.2.8.1'
@@ -53,6 +54,14 @@ jobs:
           ruby: '2.7'
         - rails: '7.2.0'
           ruby: '3.0'
+        - rails: '8.0.0'
+          ruby: '2.6'
+        - rails: '8.0.0'
+          ruby: '2.7'
+        - rails: '8.0.0'
+          ruby: '3.0'
+        - rails: '8.0.0'
+          ruby: '3.1'
     name: Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}
     env:
       RAILS_VERSION: ${{ matrix.rails }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,7 @@ jobs:
 
         # Rails 5.2 became EOL on 2022-06-01; kept for information only
         # Rails 6.0 became EOL on 2023-06-01; kept for information only
+        # Rails 6.1 became EOL on 2024-10-01; kept for information only
         rails: ['5.2.8.1', '6.0.6.1', '6.1.7.8', '7.0.8.4', '7.1.3.4', '7.2.0', '8.0.0']
 
         exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Changed
 
+- Update rails dependency in gemspec to support Rails 8.0 (https://github.com/rswag/rswag/pull/797)
+
 ## Fixed
 
 ## [2.15.0] - 2024-10-04

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 # Allow the rails version to come from an ENV setting so CI can test multiple versions.
 # See http://www.schneems.com/post/50991826838/testing-against-multiple-rails-versions/
-rails_version = ENV['RAILS_VERSION'] || '7.2.0'
+rails_version = ENV['RAILS_VERSION'] || '8.0.0'
 
 gem 'rails', rails_version.to_s
 
@@ -15,6 +15,8 @@ when '5'
   gem 'sqlite3', '~> 1.3.6'
 when  '6', '7'
   gem 'sqlite3', '~> 1.4'
+when '8'
+  gem 'sqlite3', '~> 2.2'
 end
 
 case RUBY_VERSION.split('.').first

--- a/rswag-api/rswag-api.gemspec
+++ b/rswag-api/rswag-api.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.0'
-  s.add_dependency 'railties', '>= 5.2', '< 8.0'
+  s.add_dependency 'activesupport', '>= 5.2', '< 8.1'
+  s.add_dependency 'railties', '>= 5.2', '< 8.1'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.0'
+  s.add_dependency 'activesupport', '>= 5.2', '< 8.1'
   s.add_dependency 'json-schema', '>= 2.2', '< 6.0'
-  s.add_dependency 'railties', '>= 5.2', '< 8.0'
+  s.add_dependency 'railties', '>= 5.2', '< 8.1'
   s.add_dependency 'rspec-core', '>=2.14'
 
   s.add_development_dependency 'simplecov', '=0.21.2'

--- a/rswag-ui/rswag-ui.gemspec
+++ b/rswag-ui/rswag-ui.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,node_modules}/**/*') + ['MIT-LICENSE', 'Rakefile' ]
 
-  s.add_dependency 'actionpack', '>= 5.2', '< 8.0'
-  s.add_dependency 'railties', '>= 5.2', '< 8.0'
+  s.add_dependency 'actionpack', '>= 5.2', '< 8.1'
+  s.add_dependency 'railties', '>= 5.2', '< 8.1'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/test-app/config/application.rb
+++ b/test-app/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 
 module TestApp
   class Application < Rails::Application
-    config.load_defaults 5.2
+    config.load_defaults Rails::VERSION::STRING.to_f
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
## Problem
Rails 8 was released today and the latest gemspec is not compatible.

## Solution
Update the gemspec to allow for Rails 8 and add it to the test matrix in CI.

### Checklist
- [ ] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)
