### PR TITLE
add support for 'N' swagger.json in openapi_spec

### DIFF
--- a/rswag-specs/lib/rswag/specs/configuration.rb
+++ b/rswag-specs/lib/rswag/specs/configuration.rb
@@ -48,6 +48,16 @@ module Rswag
 
       def get_openapi_spec(name)
         return openapi_specs.values.first if name.nil?
+        if name.is_a?(Array)
+          name.map do |n|
+            return_openapi_spec(n)
+          end
+        else
+          return_openapi_spec(name)
+        end
+      end
+
+      def return_openapi_spec(name)
         raise ConfigurationError, "Unknown openapi_spec '#{name}'" unless openapi_specs[name]
 
         openapi_specs[name]

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -12,7 +12,8 @@ module Rswag
       end
 
       def build_request(metadata, example)
-        swagger_doc = @config.get_openapi_spec(metadata[:openapi_spec] || metadata[:swagger_doc])
+        swagger_docs = @config.get_openapi_spec(metadata[:openapi_spec] || metadata[:swagger_doc])
+        swagger_doc = swagger_docs.is_a?(Array) ? swagger_docs.first : swagger_docs
         parameters = expand_parameters(metadata, swagger_doc, example)
 
         {}.tap do |request|

--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -30,8 +30,16 @@ module Rswag
         return if metadata[:document] == false
         return unless metadata.key?(:response)
 
-        swagger_doc = @config.get_openapi_spec(metadata[:openapi_spec] || metadata[:swagger_doc])
+        swagger_docs = @config.get_openapi_spec(metadata[:openapi_spec] || metadata[:swagger_doc])
 
+        if swagger_docs.is_a?(Array)
+          swagger_docs.each { |swagger_doc| merge_docs!(swagger_doc, metadata) }
+        else
+          merge_docs!(swagger_docs, metadata)
+        end
+      end
+
+      def merge_docs!(swagger_doc, metadata)
         unless doc_version(swagger_doc).start_with?('2')
           # This is called multiple times per file!
           # metadata[:operation] is also re-used between examples within file

--- a/rswag-specs/spec/rswag/specs/configuration_spec.rb
+++ b/rswag-specs/spec/rswag/specs/configuration_spec.rb
@@ -149,6 +149,15 @@ RSpec.describe Rswag::Specs::Configuration do
         end
       end
 
+      context 'is an array' do
+        let(:tag) { ['v1/swagger.json', 'v2/swagger.json'] }
+
+        it 'returns the matching doc in rspec config' do
+          expect(openapi_spec.first).to match hash_including(info: { title: 'v1' })
+          expect(openapi_spec.second).to match hash_including(info: { title: 'v2' })
+        end
+      end
+
       context 'no matching doc' do
         let(:tag) { 'foobar' }
         it { expect { openapi_spec }.to raise_error Rswag::Specs::ConfigurationError }

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -267,6 +267,56 @@ module Rswag
             )
           end
         end
+
+        context "with n openapi_specs" do
+          context 'with the document tag set to anything but false' do
+            let(:openapi_spec) { [{ swagger: '2.0' }, { swagger: '2.0' }] }
+            # anything works, including its absence when specifying responses.
+            let(:document) { nil }
+
+            it 'converts to swagger and merges into the corresponding swagger doc' do
+              expect(openapi_spec[0]).to match(
+                swagger: '2.0',
+                paths: {
+                  '/blogs' => {
+                    parameters: [{ type: :string }],
+                    post: {
+                      parameters: [{ type: :string }],
+                      summary: 'Creates a blog',
+                      responses: {
+                        '201' => {
+                          description: 'blog created',
+                          headers: { type: :string },
+                          schema: { '$ref' => '#/definitions/blog' }
+                        }
+                      }
+                    }
+                  }
+                }
+              )
+
+              expect(openapi_spec[1]).to match(
+                swagger: '2.0',
+                paths: {
+                  '/blogs' => {
+                    parameters: [{ type: :string }],
+                    post: {
+                      parameters: [{ type: :string }],
+                      summary: 'Creates a blog',
+                      responses: {
+                        '201' => {
+                          description: 'blog created',
+                          headers: { type: :string },
+                          schema: { '$ref' => '#/definitions/blog' }
+                        }
+                      }
+                    }
+                  }
+                }
+              )
+            end
+          end
+        end
       end
 
       describe '#stop' do
@@ -372,7 +422,7 @@ module Rswag
             })
           end
         end
-        
+
         context 'with enum parameters' do
           let(:doc_2) do
             {
@@ -401,14 +451,14 @@ module Rswag
           it 'writes the enum description' do
             expect(doc_2[:paths]['/path/'][:get][:parameters]).to match(
               [{
-                in: :query, 
-                name: :foo, 
+                in: :query,
+                name: :foo,
                 enum: {
-                  bar: "list bars", 
+                  bar: "list bars",
                   baz: "lists people named baz"
-                  }, 
+                  },
                   description: "get by foo:\n * `bar` list bars\n * `baz` lists people named baz\n "
-              }]            
+              }]
             )
           end
         end


### PR DESCRIPTION
## Problem
A clear and concise description of what the problem is.

## Solution
A clear and concise description of what the solution is.

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
