### PR TITLE
fix description for 2nd+ method's parameter with `enum`

### DIFF
--- a/rswag-specs/lib/rswag/specs/swagger_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/swagger_formatter.rb
@@ -74,10 +74,9 @@ module Rswag
                     end
                   end
 
-                  enum_param = value.dig(:parameters).find{|p| p[:enum]}
-                  if enum_param && enum_param.is_a?(Hash)
-                    enum_param[:description] = generate_enum_description(enum_param)
-                  end
+                  enum_params = value.dig(:parameters).select { |p| p[:enum]&.is_a?(Hash) }
+
+                  enum_params.each { |param| param[:description] = generate_enum_description(param) }
 
                   value[:parameters].reject! { |p| p[:in] == :body || p[:in] == :formData }
                 end

--- a/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/swagger_formatter_spec.rb
@@ -413,6 +413,65 @@ module Rswag
           end
         end
 
+        context 'with several enum parameters' do
+          let(:doc_2) do
+            {
+              paths: {
+                '/path/' => {
+                  get: {
+                    summary: 'Retrieve Nested Paths',
+                    tags: ['nested Paths'],
+                    produces: ['application/json'],
+                    consumes: ['application/json'],
+                    parameters: [{
+                                   in: :query,
+                                   name: :foo,
+                                   enum: {
+                                     'bar': 'list bars',
+                                     'baz': 'lists people named baz'
+                                   },
+                                   description: 'get by foo'
+                                 },
+                                 {
+                                   in: :query,
+                                   name: :status,
+                                   enum: {
+                                     'active': 'list with active entries',
+                                     'inactive': 'lists inactive entries'
+                                   },
+                                   description: 'entries status'
+                                 }]
+                  }
+                }
+              }
+            }
+          end
+
+          it 'writes the enum description' do
+            expect(doc_2[:paths]['/path/'][:get][:parameters]).to match(
+                                                                    [{
+                                                                       in: :query,
+                                                                       name: :foo,
+                                                                       enum: {
+                                                                         bar: "list bars",
+                                                                         baz: "lists people named baz"
+                                                                       },
+                                                                       description: "get by foo:\n * `bar` list bars\n * `baz` lists people named baz\n "
+                                                                     },
+                                                                     {
+                                                                       in: :query,
+                                                                       name: :status,
+                                                                       enum: {
+                                                                         active: "list with active entries",
+                                                                         inactive: "lists inactive entries"
+                                                                       },
+                                                                       description: "entries status:\n * `active` list with active entries\n * `inactive` lists inactive entries\n "
+                                                                     }]
+                                                                  )
+          end
+        end
+
+
         context 'with descriptions on the body param' do
           let(:doc_2) do
             {


### PR DESCRIPTION
## Problem
If method has more than one parameter with enum -- only one will have enum values in description.

## Solution
Closes https://github.com/rswag/rswag/issues/806

### This concerns this parts of the OpenAPI Specification

### The changes I made are compatible with:
- [x] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues
https://github.com/rswag/rswag/issues/806

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce

