### PR TITLE
[SECURITY] update swagger-ui-dist due to CVE-2024-47875

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## Added
+## Security
 
-## Changed
-
-## Fixed
+- Bump "swagger-ui-dist" to "5.18.3" in rswag-ui due to [CVE-2024-47875](https://nvd.nist.gov/vuln/detail/CVE-2024-47875) (https://github.com/rswag/rswag/pull/670)
 
 ## [2.16.0] - 2024-11-13
 

--- a/rswag-ui/package-lock.json
+++ b/rswag-ui/package-lock.json
@@ -8,13 +8,24 @@
       "name": "rswag-ui",
       "version": "1.0.1",
       "dependencies": {
-        "swagger-ui-dist": "5.9.4"
+        "swagger-ui-dist": "5.18.3"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/swagger-ui-dist": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.9.4.tgz",
-      "integrity": "sha512-Ppghvj6Q8XxH5xiSrUjEeCUitrasGtz7v9FCUIBR/4t89fACQ4FnUT9D0yfodUYhB+PrCmYmxwe/2jTDLslHDw=="
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.3.tgz",
+      "integrity": "sha512-G33HFW0iFNStfY2x6QXO2JYVMrFruc8AZRX0U/L71aA7WeWfX2E5Nm8E/tsipSZJeIZZbSjUDeynLK/wcuNWIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
     }
   }
 }

--- a/rswag-ui/package.json
+++ b/rswag-ui/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.1",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "5.9.4"
+    "swagger-ui-dist": "5.18.3"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/rswag/rswag/issues/810

I'm trying manual testing but even on `master` I get a failure
![image](https://github.com/user-attachments/assets/95bb36f6-ef66-4b6a-9662-0ab876207037)

![image](https://github.com/user-attachments/assets/e505d15d-ec9f-4165-953f-0eac5a926dbc)

It's fixable eventually but I'd like to get the security fix out ASAP.
I'm not currently on any projects that use RSwag so if someone can test this on a working project I'd really appreciate it :bow: 