### PR TITLE
fix: allow non-required query and body parameters

### DIFF
--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -34,7 +34,7 @@ module Rswag
         (operation_params + path_item_params + security_params)
           .map { |p| p['$ref'] ? resolve_parameter(p['$ref'], swagger_doc) : p }
           .uniq { |p| p[:name] }
-          .reject { |p| p[:required] == false && !example.respond_to?(extract_getter(p)) }
+          .select { |p| p[:required] == true || p[:in] == :path || example.respond_to?(extract_getter(p)) }
       end
 
       def derive_security_params(metadata, swagger_doc)

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -406,7 +406,7 @@ module Rswag
 
           context 'missing body parameter' do
             before do
-              metadata[:operation][:parameters] = [{ name: 'comment', in: :body, schema: { type: 'object' } }]
+              metadata[:operation][:parameters] = [{ name: 'comment', in: :body, required: true, schema: { type: 'object' } }]
               allow(example).to receive(:comment).and_raise(NoMethodError, "undefined method 'comment'")
               allow(example).to receive(:respond_to?).with(:'Content-Type')
               allow(example).to receive(:respond_to?).with('comment').and_return(false)


### PR DESCRIPTION
## Problem

https://swagger.io/specification/v2/#fixed-fields-7 
Swagger specification says that ONLY path parameter should be required by default

Field Name | Type | Description
-- | -- | --
|required|boolean|Determines whether this parameter is mandatory. If the parameter is in "path", this property is required and its value MUST be true. Otherwise, the property MAY be included and its default value is false.|

But when I run rswag spec with non-required query or body param I got multiple errors

```ruby
RSpec.describe 'Blogs API', type: :request do
  path '/blogs' do
    get 'Retrieves a page of posts' do
      produces 'application/json'

      parameter name: :page,
        in: :query,
        schema: { type: :integer, default: 1 }

      response '200', 'successful' do
        run_test!
      end
    end

    post 'Creates a blog' do
      tags 'Blogs'
      consumes 'application/json'
      parameter name: :blog, in: :body, schema: {
        type: :object,
        properties: {
          title: { type: :string },
          content: { type: :string }
        }
      }

      response '201', 'blog created' do
        run_test!
      end    
    end
  end
end

```

``` bash
> rspec spec/requests/api/blogs_spec.rb

Failures:

  1) Blogs API /blogs post blog created returns a 201 response
     Failure/Error: raise(MissingParameterError, body_param[:name]) unless example.respond_to?(body_param[:name])

     Rswag::Specs::MissingParameterError:
       Missing parameter 'blog'

       Please check your spec. It looks like you defined a body parameter,
       but did not declare usage via let. Try adding:

           let(:blog) {}
  2) Blogs API /blogs get successful returns a 200 response
     Failure/Error: super

     NoMethodError:
       undefined method `page' for #<RSpec::ExampleGroups::BlogsAPI::Blogs::Get::Successful:0x000000011e475698>
```

## Solution

Allow to define non-required query and body parameters and run rswag specs with rspec.

### This concerns this parts of the OpenAPI Specification:
* [OpenAPI Specification v3.0.0 - 4.7.12.2 Fixed Fields](https://spec.openapis.org/oas/v3.1.0#fixed-fields-9)
* [OpenAPI Specification v3.1.0 - 4.8.12.2 Fixed Fields](https://spec.openapis.org/oas/v3.1.0#fixed-fields-9)

### The changes I made are compatible with:
- [ ] OAS2
- [x] OAS3
- [x] OAS3.1

### Related Issues

Closes https://github.com/rswag/rswag/issues/802

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
