### PR TITLE
chore: update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ There is also a generator which can help get you started `rails generate rspec:s
     # spec/requests/blogs_spec.rb
     require 'swagger_helper'
 
-    describe 'Blogs API' do
+    RSpec.describe 'Blogs API', type: :request do
 
       path '/blogs' do
 


### PR DESCRIPTION
## Problem

When I go through README step by step and then run swaggerize command I got an error

```bash
> bundle exec rake rswag:specs:swaggerize

NoMethodError:
  undefined method `describe' for main

# or

NoMethodError:
  undefined method `path' for class RSpec::ExampleGroups::BlogsAPI
```

## Solution

use template from `bin/rails generate rspec:swagger API::BlogsController`

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
