### PR TITLE
V3 / fix handling of spec tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Dropped using #send (https://github.com/rswag/rswag/pull/396)
+- Fixed handling of tags in rspec contexts/tests (https://github.com/rswag/rswag/pull/825)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,13 @@ end
 
 You can set similarly the option per individual example as shown in Strict (deprecated) sections.
 
+```ruby
+      response '200', 'blog found', :openapi_no_additional_properties do
+```
+```ruby
+      response '200', 'blog found', openapi_no_additional_properties: true do
+```
+
 #### All required properties
 If you want to disallow missing required properties in response body, you can set the `openapi_all_properties_required` option to true:
 **Important** it will allow the additional properties
@@ -296,6 +303,13 @@ end
 ```
 
 You can set similarly the option per individual example as shown in Strict (deprecated) sections.
+
+```ruby
+      response '200', 'blog found', :openapi_all_properties_required do
+```
+```ruby
+      response '200', 'blog found', openapi_all_properties_required: true do
+```
 
 ### Null Values ###
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -5,15 +5,15 @@ require 'active_support'
 module Rswag
   module Specs
     module ExampleGroupHelpers
-      def path(template, metadata = {}, &block)
+      def path(template, *tags, **metadata, &block)
         metadata[:path_item] = { template: template }
-        describe(template, metadata, &block)
+        describe(template, *tags, **metadata, &block)
       end
 
       [:get, :post, :patch, :put, :delete, :head, :options, :trace].each do |verb|
-        define_method(verb) do |summary, **metadata, &block|
+        define_method(verb) do |summary, *tags, **metadata, &block|
           api_metadata = { operation: { verb: verb, summary: summary } }.deep_merge(metadata)
-          describe(verb, **api_metadata, &block)
+          describe(verb, *tags, **api_metadata, &block)
         end
       end
 
@@ -64,9 +64,9 @@ module Rswag
         end
       end
 
-      def response(code, description, metadata = {}, &block)
+      def response(code, description, *tags, **metadata, &block)
         metadata[:response] = { code: code, description: description }
-        context(description, metadata, &block)
+        context(description, *tags, **metadata, &block)
       end
 
       def schema(value)

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe 'Blogs API', type: :request, openapi_spec: 'v1/openapi.json' do
         run_test!
       end
 
-      response '200', 'blog found - openapi_all_properties_required = true', openapi_all_properties_required: true do
+      response '200', 'blog found - openapi_all_properties_required = true', openapi_all_properties_required: true do  # rubocop: disable RSpec/MetadataStyle
         schema '$ref' => '#/components/schemas/blog'
 
         let(:id) { blog.id }
@@ -181,7 +181,23 @@ RSpec.describe 'Blogs API', type: :request, openapi_spec: 'v1/openapi.json' do
         run_test!
       end
 
-      response '200', 'blog found - openapi_no_additional_properties = true', openapi_no_additional_properties: true do
+      response '200', 'blog found - openapi_no_additional_properties = true', openapi_no_additional_properties: true do  # rubocop: disable RSpec/MetadataStyle
+        schema '$ref' => '#/components/schemas/blog'
+
+        let(:id) { blog.id }
+
+        run_test!
+      end
+
+      response '200', 'blog found - tagged openapi_all_properties_required', :openapi_all_properties_required do
+        schema '$ref' => '#/components/schemas/blog'
+
+        let(:id) { blog.id }
+
+        run_test!
+      end
+
+      response '200', 'blog found - tagged :openapi_no_additional_properties', :openapi_no_additional_properties do
         schema '$ref' => '#/components/schemas/blog'
 
         let(:id) { blog.id }

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe 'Blogs API', type: :request, openapi_spec: 'v1/openapi.json' do
         run_test!
       end
 
-      response '200', 'blog found - openapi_all_properties_required = true', openapi_all_properties_required: true do  # rubocop: disable RSpec/MetadataStyle
+      response '200', 'blog found - openapi_all_properties_required = true', openapi_all_properties_required: true do  # rubocop:disable RSpec/MetadataStyle
         schema '$ref' => '#/components/schemas/blog'
 
         let(:id) { blog.id }
@@ -181,7 +181,7 @@ RSpec.describe 'Blogs API', type: :request, openapi_spec: 'v1/openapi.json' do
         run_test!
       end
 
-      response '200', 'blog found - openapi_no_additional_properties = true', openapi_no_additional_properties: true do  # rubocop: disable RSpec/MetadataStyle
+      response '200', 'blog found - openapi_no_additional_properties = true', openapi_no_additional_properties: true do  # rubocop:disable RSpec/MetadataStyle
         schema '$ref' => '#/components/schemas/blog'
 
         let(:id) { blog.id }


### PR DESCRIPTION
## Problem
Rubocop/RSpec suggests using tags instead of `true` options.
https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MetadataStyle

When I tried doing that in our test suite the tests broke.

This is because RSwag is incorrectly assuming the metadata is a positional argument hash.

## Solution

Use the modern Ruby syntax for non-specific args and kwargs being passed into a function.
`def foo(*args, **kwargs)`
Instead of the old "empty hash" style for kwargs.
`def foo(*args, kwargs = {})`

From there, `rspec-core` handles the task of turning the tags into metadata
https://github.com/rspec/rspec/blob/a80119c703d38f993c414490abe8c992154cf5d1/rspec-core/lib/rspec/core/metadata.rb#L75-L91

### Checklist
- [x] Added tests
- [x] Changelog updated
- [x] Added documentation to README.md
- [x] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce

Change `openapi_all_properties_required: true` in the `blogs_spec.rb` to `:openapi_all_properties_required` and run the tests.
