### PR TITLE
Add explicit dependency to `ostruct` in gemspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Changed
 
+- Add `ostruct` dependency in gemspec to prepare for Ruby 3.5 (https://github.com/rswag/rswag/pull/826)
+
 ## Fixed
 
 ## [2.16.0] - 2024-11-13

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json-schema', '>= 2.2', '< 6.0'
   s.add_dependency 'railties', '>= 5.2', '< 8.1'
   s.add_dependency 'rspec-core', '>=2.14'
+  s.add_dependency 'ostruct', '>= 0.1.0'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/rswag-ui/rswag-ui.gemspec
+++ b/rswag-ui/rswag-ui.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'actionpack', '>= 5.2', '< 8.1'
   s.add_dependency 'railties', '>= 5.2', '< 8.1'
+  s.add_dependency 'ostruct', '>= 0.1.0'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end


### PR DESCRIPTION
**Update: I did not see #790, I'm closing this.**

## Problem

This gem depends on the `ostruct gem`, which will no longer be part of the default gems starting from Ruby 3.5.0.

Hence it should explicitly list `ostruct` as a dependency in its gemspec.

Here is the message I get if I don't specify add `ostruct` to my Gemfile :

```
.../rswag-ui-2.16.0/lib/rswag/ui/configuration.rb:1: 
  warning: /home/francois/.rbenv/versions/3.4.2/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of rswag-ui-2.16.0 to request adding ostruct into its gemspec.
```

## Solution

Added the gem to the gemspec of `rswag-ui` and `rswag-specs`

### Checklist

- [x] Changelog updated