### PR TITLE
Support Ruby 3.4 and make CI green again

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
         # Ruby 2.6 became EOL on 2022-03-31; kept for information only
         # Ruby 2.7 became EOL on 2023-03-31; kept for information only
         # Ruby 3.0 became EOL on 2024-04-23; kept for information only
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
 
         # Rails 5.2 became EOL on 2022-06-01; kept for information only
         # Rails 6.0 became EOL on 2023-06-01; kept for information only
@@ -37,6 +37,8 @@ jobs:
           ruby: '3.2'
         - rails: '5.2.8.1'
           ruby: '3.3'
+        - rails: '5.2.8.1'
+          ruby: '3.4'
         - rails: '6.0.6.1'
           ruby: '3.0'
         - rails: '6.0.6.1'
@@ -45,8 +47,14 @@ jobs:
           ruby: '3.2'
         - rails: '6.0.6.1'
           ruby: '3.3'
+        - rails: '6.0.6.1'
+          ruby: '3.4'
+        - rails: '6.1.7.8'
+          ruby: '3.4'
         - rails: '7.0.8.4'
           ruby: '2.6'
+        - rails: '7.0.8.4'
+          ruby: '3.4'
         - rails: '7.1.3.4'
           ruby: '2.6'
         - rails: '7.2.0'
@@ -86,6 +94,8 @@ jobs:
       run: |
         if [ $(cut -d '.' -f 1 <<< "${{ matrix.ruby }}") -lt 3 ]; then
           gem update --system 3.4.22
+        elif [ "${{ matrix.ruby }}" == "3.0" ]; then
+          gem update --system 3.5.23
         else
           gem update --system
         fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Added
 
+- Add support for Ruby 3.4.
+
 ## Changed
 
 ## Fixed
+
+- Force version of concurrent-ruby for rails version >= 6 and <= 7.2
+- Force version of rubygems for ruby version == 3.0
 
 ## [2.16.0] - 2024-11-13
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,18 +4,25 @@ source 'https://rubygems.org'
 
 # Allow the rails version to come from an ENV setting so CI can test multiple versions.
 # See http://www.schneems.com/post/50991826838/testing-against-multiple-rails-versions/
-rails_version = ENV['RAILS_VERSION'] || '8.0.0'
+rails_version = Gem::Version.create(ENV['RAILS_VERSION'] || '8.0.0')
 
 gem 'rails', rails_version.to_s
 
 gem 'responders'
 
-case rails_version.split('.').first
-when '5'
+case rails_version.segments[0]
+when 5
   gem 'sqlite3', '~> 1.3.6'
-when  '6', '7'
+when  6
+  gem 'concurrent-ruby', '< 1.3.5'
   gem 'sqlite3', '~> 1.4'
-when '8'
+when 7
+  gem 'sqlite3', '~> 1.4'
+  
+  if rails_version.segments[1] < 2
+    gem 'concurrent-ruby', '< 1.3.5'
+  end
+when 8
   gem 'sqlite3', '~> 2.2'
 end
 

--- a/cspell.json
+++ b/cspell.json
@@ -28,6 +28,7 @@
     "datetime",
     "doctoc",
     "domaindrivendev",
+    "elif",
     "fdescribe",
     "fcontext",
     "jsmith",

--- a/test-app/db/schema.rb
+++ b/test-app/db/schema.rb
@@ -10,15 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2016_02_18_212104) do
-
+ActiveRecord::Schema[8.0].define(version: 2016_02_18_212104) do
   create_table "blogs", force: :cascade do |t|
     t.string "title"
     t.text "content"
     t.string "thumbnail"
     t.string "status"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
   end
-
 end

--- a/test-app/swagger/v1/swagger.json
+++ b/test-app/swagger/v1/swagger.json
@@ -14,9 +14,7 @@
         "operationId": "testBasicAuth",
         "security": [
           {
-            "basic_auth": [
-
-            ]
+            "basic_auth": []
           }
         ],
         "responses": {
@@ -38,9 +36,7 @@
         "operationId": "testApiKey",
         "security": [
           {
-            "api_key": [
-
-            ]
+            "api_key": []
           }
         ],
         "responses": {
@@ -62,12 +58,8 @@
         "operationId": "testBasicAndApiKey",
         "security": [
           {
-            "basic_auth": [
-
-            ],
-            "api_key": [
-
-            ]
+            "basic_auth": [],
+            "api_key": []
           }
         ],
         "responses": {
@@ -88,9 +80,7 @@
         ],
         "description": "Creates a new blog from provided data",
         "operationId": "createBlog",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "201": {
             "description": "blog created"
@@ -170,9 +160,7 @@
         ],
         "description": "Creates a flexible blog from provided data",
         "operationId": "createFlexibleBlog",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "201": {
             "description": "flexible blog created",
@@ -302,9 +290,7 @@
         ],
         "description": "Upload a thumbnail for specific blog by id",
         "operationId": "uploadThumbnailBlog",
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "blog updated"

--- a/test-app/swagger/v3/openapi.json
+++ b/test-app/swagger/v3/openapi.json
@@ -28,9 +28,7 @@
         "tags": [
           "Media Types"
         ],
-        "parameters": [
-
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "OK"


### PR DESCRIPTION
## Problem
* `rswag` is missing testing against ruby `3.4` in CI matrix
* CI is red

## Solution
* Added ruby `3.4` to the CI matrix
* Fixed CI:
  * force version of concurrent-ruby < 1.3.5 for rails version >= 6 and <= 7.2 (suggested in https://github.com/rails/rails/pull/54264#issuecomment-2596149819)
  * force version of rubygems == 3.5.23 also for ruby version == 3.0 (rubygems version 3.6.0 [dropped support of ruby 3.0](https://github.com/rubygems/rubygems/releases/tag/v3.6.0))

### Checklist
- [ ] Added tests
- [X] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)
