### PR TITLE
Bump swagger-ui-dist to v5.20.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Force version of concurrent-ruby for rails version >= 6 and <= 7.2
 - Force version of rubygems for ruby version == 3.0
+- Bump "swagger-ui-dist" to "5.20.6" in rswag-ui due to [CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x), [CVE-2024-39338](https://github.com/advisories/GHSA-8hc4-vh64-cxmj), [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6)
 
 ## [2.16.0] - 2024-11-13
 

--- a/rswag-ui/package-lock.json
+++ b/rswag-ui/package-lock.json
@@ -8,13 +8,24 @@
       "name": "rswag-ui",
       "version": "1.0.1",
       "dependencies": {
-        "swagger-ui-dist": "5.9.4"
+        "swagger-ui-dist": "5.20.6"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/swagger-ui-dist": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.9.4.tgz",
-      "integrity": "sha512-Ppghvj6Q8XxH5xiSrUjEeCUitrasGtz7v9FCUIBR/4t89fACQ4FnUT9D0yfodUYhB+PrCmYmxwe/2jTDLslHDw=="
+      "version": "5.20.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.20.6.tgz",
+      "integrity": "sha512-q/1dwcCOQb+qsNkb+1VWRdGEEVdBtOTH4vv9rICjPwJXOwq/JSRkBbuEMjMe161Oxsp589+8Ff5nE4HTPLWIAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
     }
   }
 }

--- a/rswag-ui/package.json
+++ b/rswag-ui/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.1",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "5.9.4"
+    "swagger-ui-dist": "5.20.6"
   }
 }


### PR DESCRIPTION
Bump "swagger-ui-dist" to "5.20.6" in rswag-ui due to [CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x), [CVE-2024-39338](https://github.com/advisories/GHSA-8hc4-vh64-cxmj), [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6)

### Checklist
- [X] Changelog updated
