### PR TITLE
fix: support OpenAPI response component references

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 203
+  Max: 208
 
 # Offense count: 6
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixed
 
+- Fix support for OpenAPI response component references (https://github.com/rswag/rswag/pull/843)
+
 - Force version of concurrent-ruby for rails version >= 6 and <= 7.2
 - Force version of rubygems for ruby version == 3.0
 - Bump "swagger-ui-dist" to "5.20.6" in rswag-ui due to [CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x), [CVE-2024-39338](https://github.com/advisories/GHSA-8hc4-vh64-cxmj), [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6)

--- a/rswag-specs/lib/rswag/specs/openapi_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/openapi_formatter.rb
@@ -91,7 +91,15 @@ module Rswag
         # Accept header
         mime_list = Array(metadata[:operation][:produces] || openapi_spec[:produces])
         target_node = metadata[:response]
-        upgrade_content!(mime_list, target_node)
+        schema = target_node[:schema]
+
+        if schema.is_a?(Hash) && schema['$ref']&.start_with?('#/components/responses/')
+          # Response component reference - use $ref directly
+          target_node.replace(schema.merge(code: target_node[:code]))
+        else
+          upgrade_content!(mime_list, target_node)
+        end
+
         metadata[:response].delete(:schema)
       end
 

--- a/rswag-specs/spec/rswag/specs/openapi_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/openapi_formatter_spec.rb
@@ -77,6 +77,37 @@ module Rswag
             )
           end
         end
+
+        context 'with response component reference' do
+          let(:openapi_spec) { { openapi: '3.0' } }
+          let(:document) { nil }
+          let(:response_metadata) do
+            { code: '400', description: 'Bad Request',
+              schema: { '$ref' => '#/components/responses/BadRequest' } }
+          end
+
+          it 'generates direct response reference without content wrapper' do
+            expect(openapi_spec).to match(
+              {
+                openapi: '3.0',
+                paths: {
+                  '/blogs' => {
+                    parameters: [{ schema: { type: :string } }],
+                    post: {
+                      parameters: [{ schema: { type: :string } }],
+                      summary: 'Creates a blog',
+                      responses: {
+                        '400' => {
+                          '$ref' => '#/components/responses/BadRequest'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            )
+          end
+        end
       end
 
       describe '#stop' do

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe 'Blogs API', openapi_spec: 'v1/openapi.json', type: :request do
           expect(response.body).to include("can't be blank")
         end
       end
+
+      response '400', 'bad request' do
+        schema '$ref' => '#/components/responses/BadRequest'
+
+        let(:request_params) { { 'blog' => { title: '' } } }
+
+        run_test!
+      end
     end
 
     get 'Searches blogs' do

--- a/test-app/spec/openapi_helper.rb
+++ b/test-app/spec/openapi_helper.rb
@@ -36,6 +36,16 @@ RSpec.configure do |config|
         }
       ],
       components: {
+        responses: {
+          BadRequest: {
+            description: 'Bad Request',
+            content: {
+              'application/json' => {
+                schema: { '$ref' => '#/components/schemas/errors_object' }
+              }
+            }
+          }
+        },
         schemas: {
           errors_object: {
             type: 'object',


### PR DESCRIPTION
## Problem
Issue #819 - Users expected `schema '$ref' => '#/components/responses/BadRequest'` to work but rswag incorrectly wrapped response component references in content structure instead of using direct `$ref`.

## Solution
Add detection logic in `openapi_formatter.rb` to identify response component references by checking if `$ref` starts with `#/components/responses/`. When detected, generate direct reference instead of wrapping in content structure.

### This concerns this parts of the OpenAPI Specification:
* [Response Object](https://spec.openapis.org/oas/v3.1.0#response-object)
* [Components Object](https://spec.openapis.org/oas/v3.1.0#components-object)

### The changes I made are compatible with:
- [x] OAS3
- [x] OAS3.1

### Related Issues
Fixes #819

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
- [x] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
1. Define a response component in `spec/openapi_helper.rb` (like our `BadRequest` component)
2. Use `schema '$ref' => '#/components/responses/BadRequest'` in a response spec
3. Run `rake rswag` to generate OpenAPI docs
4. Verify the generated JSON contains direct `"$ref": "#/components/responses/BadRequest"` instead of content wrapper

Thanks for maintaining this gem\!