### PR TITLE
Remove invalid trailing whitespace in CSP header

### DIFF
--- a/rswag-ui/lib/rswag/ui/middleware.rb
+++ b/rswag-ui/lib/rswag/ui/middleware.rb
@@ -43,7 +43,7 @@ module Rswag
       end
 
       def csp
-        <<~POLICY.tr "\n", ' '
+        <<~POLICY.tr("\n", ' ').rstrip
           default-src 'self';
           img-src 'self' data: https://validator.swagger.io;
           font-src 'self' https://fonts.gstatic.com;


### PR DESCRIPTION
## Problem
The CSP header created here had a space after the last semicolon. That does not conform to the specification.

The CSP [specification](https://w3c.github.io/webappsec-csp/#grammardef-serialized-policy) defines
```
Content-Security-Policy = 1#[serialized-policy]
serialized-policy =
    serialized-directive *( optional-ascii-whitespace ";" [ optional-ascii-whitespace serialized-directive ] )
```

So a directive follow by optional ascii whitespace and a semicolon is valid. What isn't valid is more whitespace after the semicolon (unless followed by another semicolon or a serialized-directive).

## Solution
Remove the trailing space

### This concerns this parts of the OpenAPI Specification:
N/A

### The changes I made are compatible with:
N/A

### Related Issues
This was an issue for at least the parser in [Capybara](https://github.com/teamcapybara/capybara/issues/2689)

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
