### PR TITLE
Fix rack status which needs to be an integer

### DIFF
--- a/rswag-api/lib/rswag/api/middleware.rb
+++ b/rswag-api/lib/rswag/api/middleware.rb
@@ -28,7 +28,7 @@ module Rswag
           body = unload_openapi(filename, openapi)
 
           return [
-            '200',
+            200,
             headers,
             [body]
           ]

--- a/rswag-api/spec/rswag/api/middleware_spec.rb
+++ b/rswag-api/spec/rswag/api/middleware_spec.rb
@@ -28,7 +28,7 @@ describe Rswag::Api::Middleware do
 
       it 'returns a 200 status' do
         expect(response.length).to eql(3)
-        expect(response.first).to eql('200')
+        expect(response.first).to eql(200)
       end
 
       it 'returns contents of the openapi file' do
@@ -44,7 +44,7 @@ describe Rswag::Api::Middleware do
 
         it 'returns a 200 status' do
           expect(response.length).to eql(3)
-          expect(response.first).to eql('200')
+          expect(response.first).to eql(200)
         end
       end
     end
@@ -59,7 +59,7 @@ describe Rswag::Api::Middleware do
 
         it 'returns a 200 status' do
           expect(response.length).to eql(3)
-          expect(response.first).to eql('200')
+          expect(response.first).to eql(200)
         end
 
         it 'applies the headers to the response' do
@@ -74,7 +74,7 @@ describe Rswag::Api::Middleware do
 
         it 'returns a 200 status' do
           expect(response.length).to eql(3)
-          expect(response.first).to eql('200')
+          expect(response.first).to eql(200)
         end
 
         it 'applies the headers to the response' do
@@ -91,11 +91,11 @@ describe Rswag::Api::Middleware do
       let(:env) { env_defaults.merge('PATH_INFO' => 'foobar.json') }
 
       before do
-        allow(app).to receive(:call).and_return(['500', {}, []])
+        allow(app).to receive(:call).and_return([500, {}, []])
       end
 
       it 'delegates to the next middleware' do
-        expect(response).to include('500')
+        expect(response).to include(500)
       end
     end
 
@@ -103,11 +103,11 @@ describe Rswag::Api::Middleware do
       let(:env) { env_defaults.merge('PATH_INFO' => '../traverse-secret.yml') }
 
       before do
-        allow(app).to receive(:call).and_return(['500', {}, []])
+        allow(app).to receive(:call).and_return([500, {}, []])
       end
 
       it 'delegates to the next middleware' do
-        expect(response).to include('500')
+        expect(response).to include(500)
       end
     end
 
@@ -163,7 +163,7 @@ describe Rswag::Api::Middleware do
 
       it 'returns a 200 status' do
         expect(response.length).to eql(3)
-        expect(response.first).to eql('200')
+        expect(response.first).to eql(200)
       end
 
       it 'returns contents of the openapi file' do


### PR DESCRIPTION
The Rack status needs to be an integer, and we return a string.
See https://www.rubydoc.info/github/rack/rack/file/SPEC.rdoc#label-The+Status

This is causing issues in rack methods such as [server_error](https://github.com/rack/rack/blob/main/lib/rack/response.rb#L187), as strings can't be compared with integers.