### PR TITLE
Update gemspec to support Rails 8.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
         # Rails 5.2 became EOL on 2022-06-01; kept for information only
         # Rails 6.0 became EOL on 2023-06-01; kept for information only
         # Rails 6.1 became EOL on 2024-10-01; kept for information only
-        rails: ['5.2.8.1', '6.0.6.1', '6.1.7.8', '7.0.8.4', '7.1.3.4', '7.2.0', '8.0.0']
+        rails: ['5.2.8.1', '6.0.6.1', '6.1.7.8', '7.0.8.4', '7.1.3.4', '7.2.0', '8.0.0', '8.1.0']
 
         exclude:
         # Excludes Rails 5.2 on Ruby 3.0+
@@ -29,6 +29,7 @@ jobs:
         # Excludes Rails 7.1 on Ruby 2.6
         # Excludes Rails 7.2 on Ruby 2.6, 2.7, 3.0
         # Excludes Rails 8.0 on Ruby 2.6, 2.7, 3.0, 3.1
+        # Excludes Rails 8.1 on Ruby 2.6, 2.7, 3.0, 3.1
         - rails: '5.2.8.1'
           ruby: '3.0'
         - rails: '5.2.8.1'
@@ -62,6 +63,14 @@ jobs:
         - rails: '8.0.0'
           ruby: '3.0'
         - rails: '8.0.0'
+          ruby: '3.1'
+        - rails: '8.1.0'
+          ruby: '2.6'
+        - rails: '8.1.0'
+          ruby: '2.7'
+        - rails: '8.1.0'
+          ruby: '3.0'
+        - rails: '8.1.0'
           ruby: '3.1'
     name: Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Changed
 
+- Update rails dependency in gemspec to support Rails 8.1 (https://github.com/rswag/rswag/pull/860)
+- Relax the dependency on json-schema to allow v6. (https://github.com/rswag/rswag/pull/860)
+
 ## Fixed
 
 ## [2.16.0] - 2024-11-13

--- a/rswag-api/rswag-api.gemspec
+++ b/rswag-api/rswag-api.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile']
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.1'
-  s.add_dependency 'railties', '>= 5.2', '< 8.1'
+  s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
+  s.add_dependency 'railties', '>= 5.2', '< 8.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.1'
+  s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
   s.add_dependency 'json-schema', '>= 2.2', '< 6.0'
-  s.add_dependency 'railties', '>= 5.2', '< 8.1'
+  s.add_dependency 'railties', '>= 5.2', '< 8.2'
   s.add_dependency 'rspec-core', '>=2.14'
 
   s.add_development_dependency 'simplecov', '=0.21.2'

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
   s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
-  s.add_dependency 'json-schema', '>= 2.2', '< 6.0'
+  s.add_dependency 'json-schema', '>= 2.2', '< 7.0'
   s.add_dependency 'railties', '>= 5.2', '< 8.2'
   s.add_dependency 'rspec-core', '>=2.14'
 

--- a/rswag-ui/rswag-ui.gemspec
+++ b/rswag-ui/rswag-ui.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,node_modules}/**/*') + ['MIT-LICENSE', 'Rakefile' ]
 
-  s.add_dependency 'actionpack', '>= 5.2', '< 8.1'
-  s.add_dependency 'railties', '>= 5.2', '< 8.1'
+  s.add_dependency 'actionpack', '>= 5.2', '< 8.2'
+  s.add_dependency 'railties', '>= 5.2', '< 8.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end


### PR DESCRIPTION
## Problem
Rails 8.1 was released today and the gem is currently not compatible.

## Solution
Updating the gemspec files to allow Rails 8.1

### The changes I made are compatible with:
- [x] OAS3
- [x] OAS3.1

### Checklist
- [ ] Added tests
- [x] Changelog updated