### PR TITLE
Update gemspec to support Rails 8.1 for v3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,16 +13,21 @@ jobs:
       fail-fast: false
       matrix:
         # Ruby 3.0 became EOL on 2024-04-23; kept for information only
+        # Ruby 3.1 became EOL on 2025-03-31; kept for information only
         ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
 
         # Rails 6.0 became EOL on 2023-06-01; kept for information only
-        rails: ['6.0.6.1', '6.1.7.8', '7.0.8.4', '7.1.3.4', '7.2.0', '8.0.0']
+        # Rails 6.1 became EOL on 2024-10-01; kept for information only
+        # Rails 7.0 became EOL on 2025-04-01; kept for information only
+        # Rails 7.1 became EOL on 2025-10-01; kept for information only
+        rails: ['6.0.6.1', '6.1.7.8', '7.0.8.4', '7.1.3.4', '7.2.0', '8.0.0', '8.1.0']
 
         exclude:
         # Excludes Rails 6.0 on Ruby 3.0+
         # Excludes Rails 7.0 on Ruby 3.4
         # Excludes Rails 7.2 on Ruby 3.0
         # Excludes Rails 8.0 on Ruby 2.6, 2.7, 3.0, 3.1
+        # Excludes Rails 8.1 on Ruby 2.6, 2.7, 3.0, 3.1
         - rails: '6.0.6.1'
           ruby: '3.0'
         - rails: '6.0.6.1'
@@ -46,6 +51,14 @@ jobs:
         - rails: '8.0.0'
           ruby: '3.0'
         - rails: '8.0.0'
+          ruby: '3.1'
+        - rails: '8.1.0'
+          ruby: '2.6'
+        - rails: '8.1.0'
+          ruby: '2.7'
+        - rails: '8.1.0'
+          ruby: '3.0'
+        - rails: '8.1.0'
           ruby: '3.1'
     name: Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Drop support for OpenAPI v2 (Swagger) (https://github.com/rswag/rswag/pull/574)
 - Drop Rspec V2 support (https://github.com/rswag/rswag/pull/636)
 - upgrade to ruby 3.0.6 and rails 7.0.4.3 in local dev (https://github.com/rswag/rswag/pull/625)
+- Update rails dependency in gemspec to support Rails 8.1 (https://github.com/rswag/rswag/pull/867)
+- Relax the dependency on json-schema to allow v6. (https://github.com/rswag/rswag/pull/867)
 
 ### Documentation
 

--- a/rswag-api/rswag-api.gemspec
+++ b/rswag-api/rswag-api.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + %w[MIT-LICENSE Rakefile]
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.1'
-  s.add_dependency 'railties', '>= 5.2', '< 8.1'
+  s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
+  s.add_dependency 'railties', '>= 5.2', '< 8.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
   s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
-  s.add_dependency 'json-schema', '>= 2.2', '< 6.0'
+  s.add_dependency 'json-schema', '>= 2.2', '< 7.0'
   s.add_dependency 'railties', '>= 5.2', '< 8.2'
   s.add_dependency 'rspec-core', '>=3.12'
 

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.1'
+  s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
   s.add_dependency 'json-schema', '>= 2.2', '< 6.0'
-  s.add_dependency 'railties', '>= 5.2', '< 8.1'
+  s.add_dependency 'railties', '>= 5.2', '< 8.2'
   s.add_dependency 'rspec-core', '>=3.12'
 
   s.add_development_dependency 'simplecov', '=0.21.2'

--- a/rswag-ui/rswag-ui.gemspec
+++ b/rswag-ui/rswag-ui.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,node_modules}/**/*') + %w[MIT-LICENSE Rakefile]
 
-  s.add_dependency 'actionpack', '>= 5.2', '< 8.1'
-  s.add_dependency 'railties', '>= 5.2', '< 8.1'
+  s.add_dependency 'actionpack', '>= 5.2', '< 8.2'
+  s.add_dependency 'railties', '>= 5.2', '< 8.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end


### PR DESCRIPTION
## Problem
Follow-up for #860. Pretty much the same changes, but for v3 in the master branch

### The changes I made are compatible with:
- [x] OAS3
- [x] OAS3.1

### Related Issues
#861

### Checklist
- [x] Changelog updated
