### PR TITLE
Do not pass redundant block to `assert_response_matches_metadata`

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -129,7 +129,7 @@ module Rswag
         end
 
         it description, *args, **options do |example|
-          assert_response_matches_metadata(example.metadata, &block)
+          assert_response_matches_metadata(example.metadata)
           example.instance_exec(response, &block) if block_given?
         end
       end


### PR DESCRIPTION
## Problem
Looks like `assert_response_matches_metadata` does not use provided block, so it should be safe to remove it.

This produces a warning:

```shell
warning: the block passed to 'assert_response_matches_metadata' defined at <snip> may be ignored
```


## Solution
Do not pass any blocks to this method.

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [X] OAS3
- [X] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
