### PR TITLE
Remove ostruct require statements

### DIFF
--- a/rswag-specs/spec/rswag/specs/openapi_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/openapi_formatter_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rswag/specs/openapi_formatter'
-require 'ostruct'
 
 module Rswag
   module Specs

--- a/rswag-ui/lib/rswag/ui/configuration.rb
+++ b/rswag-ui/lib/rswag/ui/configuration.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
 require 'rack'
 
 module Rswag


### PR DESCRIPTION
The OpenStructs have [previously been removed](https://github.com/rswag/rswag/commit/389e40155f1a33e23172bd57bf29de30e0ee26ce). The ostruct lib does not need to be required anymore. It's also not a part of the standardlib in ruby 3.5 / 4.0 anymore so it shouldn't be here by then.

Using rswag currently emits a warning:

```
/gems/rswag-ui-2.17.0/lib/rswag/ui/configuration.rb:1: 
warning: /lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, 
but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of rswag-ui-2.17.0 to request adding ostruct into its gemspec.
```