### PR TITLE
Clarify how to pass metadata in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,13 @@ end
 
 You can set similarly the option per individual example as shown in Strict (deprecated) sections.
 
+Note: The following syntax is supported only in rswag-specs >= 3.0.0.pre:
+
 ```ruby
       response '200', 'blog found', :openapi_no_additional_properties do
 ```
+For rswag-specs versions < 3.0.0, metadata must be passed as a hash:
+
 ```ruby
       response '200', 'blog found', openapi_no_additional_properties: true do
 ```
@@ -304,9 +308,13 @@ end
 
 You can set similarly the option per individual example as shown in Strict (deprecated) sections.
 
+Note: The following syntax is supported only in rswag-specs >= 3.0.0.pre:
+
 ```ruby
       response '200', 'blog found', :openapi_all_properties_required do
 ```
+For rswag-specs versions < 3.0.0, metadata must be passed as a hash:
+
 ```ruby
       response '200', 'blog found', openapi_all_properties_required: true do
 ```


### PR DESCRIPTION
## Problem
The current README has 2 code snippets on how to specify schema validations. I assumed both are valid. But turned out one will only work for latest pre release.

## Solution
Updated README.md to clarify how to pass metadata to the `response`. Use of tags is only supported for rswag-specs >= 3.0.0.pre. As I can see was fixed in #825

