### PR TITLE
Remove upper bound dependency on Rails gems

### DIFF
--- a/rswag-api/rswag-api.gemspec
+++ b/rswag-api/rswag-api.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + %w[MIT-LICENSE Rakefile]
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
-  s.add_dependency 'railties', '>= 5.2', '< 8.2'
+  s.add_dependency 'activesupport', '>= 5.2'
+  s.add_dependency 'railties', '>= 5.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end

--- a/rswag-specs/rswag-specs.gemspec
+++ b/rswag-specs/rswag-specs.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', '.rubocop_rspec_alias_config.yml']
 
-  s.add_dependency 'activesupport', '>= 5.2', '< 8.2'
+  s.add_dependency 'activesupport', '>= 5.2'
   s.add_dependency 'json-schema', '>= 2.2', '< 7.0'
-  s.add_dependency 'railties', '>= 5.2', '< 8.2'
+  s.add_dependency 'railties', '>= 5.2'
   s.add_dependency 'rspec-core', '>=3.12'
 
   s.add_development_dependency 'simplecov', '=0.21.2'

--- a/rswag-ui/rswag-ui.gemspec
+++ b/rswag-ui/rswag-ui.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{lib,node_modules}/**/*') + %w[MIT-LICENSE Rakefile]
 
-  s.add_dependency 'actionpack', '>= 5.2', '< 8.2'
-  s.add_dependency 'railties', '>= 5.2', '< 8.2'
+  s.add_dependency 'actionpack', '>= 5.2'
+  s.add_dependency 'railties', '>= 5.2'
 
   s.add_development_dependency 'simplecov', '=0.21.2'
 end


### PR DESCRIPTION
I'd like to test our app against Rails edge, but this gem is preventing it because it has a pessimistic constraint on Rails gems.

There is no reason to believe 8.2 will break this gem, but even if it does, by allowing edge testing you are likely to receive a fix long in advance of the final release, which is preferable.
