### PR TITLE
add `writeOnly` support for response validation

### DIFF
--- a/rswag-specs/lib/rswag/specs/extended_schema.rb
+++ b/rswag-specs/lib/rswag/specs/extended_schema.rb
@@ -4,11 +4,64 @@ require 'json-schema'
 
 module Rswag
   module Specs
+    class ResponseRequiredAttribute < JSON::Schema::RequiredAttribute
+      def self.validate(current_schema, data, fragments, processor, validator, options = {})
+        return super unless data.is_a?(Hash)
+
+        filtered_schema = remove_write_only_required_properties(current_schema, validator)
+
+        super(filtered_schema, data, fragments, processor, validator, options)
+      end
+
+      # For response validation, OpenAPI says `writeOnly` properties are not required.
+      # This method removes those properties from the required list for validation
+      private_class_method def self.remove_write_only_required_properties(current_schema, validator)
+        filtered_required = current_schema.schema['required'].reject do |property|
+          property_schema = current_schema.schema.fetch('properties', {})[property.to_s]
+          property_schema.is_a?(Hash) && property_schema['writeOnly'] == true
+        end
+
+        return current_schema if filtered_required == current_schema.schema['required']
+
+        JSON::Schema.new(
+          current_schema.schema.merge('required' => filtered_required),
+          current_schema.uri,
+          validator
+        )
+      end
+    end
+
+    class ResponsePropertiesV4Attribute < JSON::Schema::PropertiesV4Attribute
+      # This hook only runs when requiredness comes from `allPropertiesRequired: true`.
+      # It does not handle an explicit `required: [...]` array; that case is handled by
+      # ResponseRequiredAttribute above.
+      #
+      # Example handled here:
+      #   schema:
+      #     type: object
+      #     properties:
+      #       password:
+      #         type: string
+      #         writeOnly: true
+      #
+      #   options:
+      #     allPropertiesRequired: true
+      #
+      # Draft 4 would treat `password` as required because every property becomes
+      # required. For response validation, OpenAPI says `writeOnly` properties stay
+      # optional, so this returns false for that property.
+      def self.required?(schema, options)
+        super && schema['writeOnly'] != true
+      end
+    end
+
     class ExtendedSchema < JSON::Schema::Draft4
       def initialize
         super
         @uri = URI.parse('http://tempuri.org/rswag/specs/extended_schema')
         @names = ['http://tempuri.org/rswag/specs/extended_schema']
+        @attributes['properties'] = ResponsePropertiesV4Attribute
+        @attributes['required'] = ResponseRequiredAttribute
       end
 
       def validate(current_schema, data, *)

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -348,6 +348,50 @@ module Rswag
             it "serializes first 'body' parameter to JSON string" do
               expect(request[:payload]).to eq('{"text":"Some comment"}')
             end
+
+            context 'when the request schema has a writeOnly property' do
+              before do
+                metadata[:operation][:parameters] = [
+                  {
+                    name: 'comment',
+                    in: :body,
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        password: { type: 'string', writeOnly: true }
+                      }
+                    }
+                  }
+                ]
+                example.request_params['comment'] = { password: 'secret' }
+              end
+
+              it 'keeps request payload serialization unchanged' do
+                expect(request[:payload]).to eq('{"password":"secret"}')
+              end
+            end
+
+            context 'when the request schema has a readOnly property' do
+              before do
+                metadata[:operation][:parameters] = [
+                  {
+                    name: 'comment',
+                    in: :body,
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'integer', readOnly: true }
+                      }
+                    }
+                  }
+                ]
+                example.request_params['comment'] = { id: 1 }
+              end
+
+              it 'keeps request payload serialization unchanged' do
+                expect(request[:payload]).to eq('{"id":1}')
+              end
+            end
           end
 
           context 'JSON:API payload' do

--- a/rswag-specs/spec/rswag/specs/response_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/response_validator_spec.rb
@@ -552,6 +552,149 @@ module Rswag
           end
         end
 
+        context 'when schema uses readOnly and writeOnly properties' do
+          let(:schema) do
+            {
+              type: :object,
+              properties: {
+                id: { type: :integer, readOnly: true },
+                password: { type: :string, writeOnly: true }
+              },
+              required: %w[id password]
+            }
+          end
+
+          context 'when the response includes readOnly and omits writeOnly' do
+            let(:response) do
+              Response.new(
+                code: '200',
+                headers: {
+                  'X-Rate-Limit-Limit' => '10',
+                  'X-Cursor' => 'test_cursor',
+                  'X-Per-Page' => 25
+                },
+                body: '{"id":1}'
+              )
+            end
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'when the response omits a required readOnly property' do
+            let(:response) do
+              Response.new(
+                code: '200',
+                headers: {
+                  'X-Rate-Limit-Limit' => '10',
+                  'X-Cursor' => 'test_cursor',
+                  'X-Per-Page' => 25
+                },
+                body: '{}'
+              )
+            end
+
+            it { expect { call }.to raise_error(/Expected response body/) }
+          end
+
+          context 'when the response includes a writeOnly property' do
+            let(:response) do
+              Response.new(
+                code: '200',
+                headers: {
+                  'X-Rate-Limit-Limit' => '10',
+                  'X-Cursor' => 'test_cursor',
+                  'X-Per-Page' => 25
+                },
+                body: '{"id":1,"password":"secret"}'
+              )
+            end
+
+            it { expect { call }.not_to raise_error }
+          end
+        end
+
+        context 'when all properties are required for response validation' do
+          let(:openapi_all_properties_required) { true }
+          let(:schema) do
+            {
+              type: :object,
+              properties: {
+                id: { type: :integer, readOnly: true },
+                password: { type: :string, writeOnly: true }
+              }
+            }
+          end
+
+          context 'when the response includes readOnly and omits writeOnly' do
+            let(:response) do
+              Response.new(
+                code: '200',
+                headers: {
+                  'X-Rate-Limit-Limit' => '10',
+                  'X-Cursor' => 'test_cursor',
+                  'X-Per-Page' => 25
+                },
+                body: '{"id":1}'
+              )
+            end
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'when the response omits a readOnly property' do
+            let(:response) do
+              Response.new(
+                code: '200',
+                headers: {
+                  'X-Rate-Limit-Limit' => '10',
+                  'X-Cursor' => 'test_cursor',
+                  'X-Per-Page' => 25
+                },
+                body: '{}'
+              )
+            end
+
+            it { expect { call }.to raise_error(/Expected response body/) }
+          end
+        end
+
+        context 'when a referenced schema uses readOnly and writeOnly properties' do
+          let(:openapi_spec) do
+            {
+              components: {
+                schemas: {
+                  'User' => {
+                    type: :object,
+                    properties: {
+                      id: { type: :integer, readOnly: true },
+                      password: { type: :string, writeOnly: true }
+                    },
+                    required: %w[id password]
+                  }
+                }
+              }
+            }
+          end
+
+          before do
+            metadata[:response][:schema] = { '$ref' => '#/components/schemas/User' }
+          end
+
+          let(:response) do
+            Response.new(
+              code: '200',
+              headers: {
+                'X-Rate-Limit-Limit' => '10',
+                'X-Cursor' => 'test_cursor',
+                'X-Per-Page' => 25
+              },
+              body: '{"id":1}'
+            )
+          end
+
+          it { expect { call }.not_to raise_error }
+        end
+
         context 'referenced schemas' do
           context 'components/schemas' do
             before do


### PR DESCRIPTION
I've used RSwag for a while, but first time contributor.

Disclaimer: Implemented with AI, but I did multiple tweaks. It makes sense to me, but I don't know the internals that well.

Happy to do changes or receive suggestions. 

As I understand this, json schema validation cannot cover `writeOnly`, and it is an extra layer we have to add. To do the minimum amount of changes, what we do is just remove the properties that have `writeOnly` and are part of the `required` list.