### PR TITLE
Support for JSON-formatted query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Added support for JSON-formatted query parameters (https://github.com/rswag/rswag/pull/883)
+
 ### Changed
 
 - Drop support for OpenAPI v2 (Swagger) (https://github.com/rswag/rswag/pull/574)

--- a/rswag-specs/lib/rswag/specs/request_factory.rb
+++ b/rswag-specs/lib/rswag/specs/request_factory.rb
@@ -120,41 +120,54 @@ module Rswag
       def build_query_string_part(param, value, _openapi_spec)
         raise ArgumentError, "'type' is not supported field for Parameter" unless param[:type].nil?
 
-        name = param[:name]
-        escaped_name = CGI.escape(name.to_s)
+        name = param[:name].to_s
 
-        # NOTE: https://swagger.io/docs/specification/serialization/
+        # NOTE: OpenAPI 3.0+ allows nesting schema under a content key. Having 'application/json'
+        # content type on query parameters allows for a JSON-formatted query parameter.
+        # See: https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content
+        content = (param[:content] || {}).transform_keys(&:to_sym)
+        return { name => value.to_json }.to_query if content.dig(:'application/json', :schema)
         return unless param[:schema]
 
+        # NOTE: https://swagger.io/docs/specification/serialization/
         style = param[:style]&.to_sym || :form
         explode = param[:explode].nil? || param[:explode]
         type = param.dig(:schema, :type)&.to_sym
 
         case type
         when :object
-          case style
-          when :deepObject
-            { name => value }.to_query
-          when :form
-            return value.to_query if explode
-
-            "#{escaped_name}=" + value.to_a.flatten.map { |v| CGI.escape(v.to_s) }.join(',')
-
-          end
+          serialize_object_query_param(name, value, style, explode)
         when :array
-          case explode
-          when true
-            value.to_a.flatten.map { |v| "#{escaped_name}=#{CGI.escape(v.to_s)}" }.join('&')
-          else
-            separator = case style
-                        when :form then ','
-                        when :spaceDelimited then '%20'
-                        when :pipeDelimited then '|'
-                        end
-            "#{escaped_name}=" + value.to_a.flatten.map { |v| CGI.escape(v.to_s) }.join(separator)
-          end
+          serialize_array_query_param(name, value, style, explode)
         else
-          "#{escaped_name}=#{CGI.escape(value.to_s)}"
+          "#{CGI.escape(name)}=#{CGI.escape(value.to_s)}"
+        end
+      end
+
+      def serialize_object_query_param(name, value, style, explode)
+        case style
+        when :deepObject
+          { name => value }.to_query
+        when :form
+          return value.to_query if explode
+
+          escaped_name = CGI.escape(name.to_s)
+          "#{escaped_name}=" + value.to_a.flatten.map { |v| CGI.escape(v.to_s) }.join(',')
+        end
+      end
+
+      def serialize_array_query_param(name, value, style, explode)
+        escaped_name = CGI.escape(name.to_s)
+
+        if explode
+          value.to_a.flatten.map { |v| "#{escaped_name}=#{CGI.escape(v.to_s)}" }.join('&')
+        else
+          separator = case style
+                      when :form then ','
+                      when :spaceDelimited then '%20'
+                      when :pipeDelimited then '|'
+                      end
+          "#{escaped_name}=" + value.to_a.flatten.map { |v| CGI.escape(v.to_s) }.join(separator)
         end
       end
 

--- a/rswag-specs/spec/rswag/specs/request_factory_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_factory_spec.rb
@@ -193,6 +193,31 @@ module Rswag
           end
         end
 
+        context "'query' parameter with content: application/json" do
+          let(:openapi_spec) { { openapi: '3.0' } }
+          let(:filters) do
+            { date_from: '2026-04-01' }
+          end
+
+          before do
+            metadata[:operation][:parameters] = [
+              {
+                name: 'filters', in: :query,
+                content: {
+                  'application/json' => {
+                    schema: { type: :object, properties: { date_from: { type: :string } } }
+                  }
+                }
+              }
+            ]
+            example.request_params['filters'] = filters
+          end
+
+          it 'JSON-encodes and percent-encodes the value' do
+            expect(request[:path]).to eq('/blogs?filters=%7B%22date_from%22%3A%222026-04-01%22%7D')
+          end
+        end
+
         context "'query' parameters of type 'array'" do
           let(:id) { [3, 4, 5] }
           let(:openapi_spec) { { openapi: '3.0' } }

--- a/test-app/app/controllers/blogs_controller.rb
+++ b/test-app/app/controllers/blogs_controller.rb
@@ -40,6 +40,13 @@ class BlogsController < ApplicationController
     @blogs = Blog.all
     @blogs = @blogs.where(status: params[:status]) if params[:status].present?
 
+    if search_filters[:date_from]
+      @blogs = @blogs.where(created_at: search_filters[:date_from]..)
+    end
+    if search_filters[:date_to]
+      @blogs = @blogs.where(created_at: ..search_filters[:date_to])
+    end
+
     respond_with @blogs
   end
 
@@ -56,6 +63,29 @@ class BlogsController < ApplicationController
   end
 
   private
+
+  def search_filters
+    return @search_filters if defined?(@search_filters)
+
+    @search_filters = begin
+                value = JSON.parse(params[:filters], symbolize_names: true)
+                value.is_a?(Hash) ? value : {}
+              rescue TypeError, JSON::ParserError
+                {}
+              end
+    @search_filters.each do |key, value|
+      next unless %i[date_from date_to].include?(key)
+
+      @search_filters[key] = begin
+                       value = Time.parse(value).utc
+                       value = value.beginning_of_day if key == :date_from
+                       value = value.end_of_day if key == :date_to
+                       value
+                     rescue ArgumentError
+                     end
+    end
+    @search_filters
+  end
 
   def save_uploaded_file(field)
     return if field.nil?

--- a/test-app/openapi/v1/openapi.json
+++ b/test-app/openapi/v1/openapi.json
@@ -165,6 +165,30 @@
               }
             },
             "description": "Filter by status"
+          },
+          {
+            "name": "filters",
+            "in": "query",
+            "description": "JSON-encoded filter object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "date_from": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "Filter blogs created from this date"
+                    },
+                    "date_to": {
+                      "type": "string",
+                      "format": "date",
+                      "description": "Filter blogs created up to this date"
+                    }
+                  }
+                }
+              }
+            }
           }
         ],
         "responses": {
@@ -253,7 +277,7 @@
         "operationId": "getBlog",
         "responses": {
           "200": {
-            "description": "blog found - openapi_no_additional_properties = true",
+            "description": "blog found - tagged :openapi_no_additional_properties",
             "headers": {
               "ETag": {
                 "schema": {

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -54,6 +54,28 @@ RSpec.describe 'Blogs API', openapi_spec: 'v1/openapi.json', type: :request do
                   }
                 },
                 description: 'Filter by status'
+      parameter name: 'filters',
+                in: :query,
+                description: 'JSON-encoded filter object',
+                content: {
+                  'application/json' => {
+                    schema: {
+                      type: :object,
+                      properties: {
+                        date_from: {
+                          type: :string,
+                          format: 'date',
+                          description: 'Filter blogs created from this date',
+                        },
+                        date_to: {
+                          type: :string,
+                          format: 'date',
+                          description: 'Filter blogs created up to this date',
+                        }
+                      }
+                    }
+                  }
+                }
 
       before do
         Blog.create(title: 'foo', content: 'hello world', status: :published)
@@ -62,7 +84,11 @@ RSpec.describe 'Blogs API', openapi_spec: 'v1/openapi.json', type: :request do
       let(:request_params) do
         {
           'keywords' => 'foo bar',
-          'status' => 'published'
+          'status' => 'published',
+          'filters' => {
+            'date_from' => 1.day.ago.to_date.to_s,
+            'date_to' => Time.current.to_date.to_s
+          }
         }
       end
 


### PR DESCRIPTION
## Problem

OpenAPI 3.0+ supports nesting parameters schema under a `content` property - that allows for defining json-formatted parameter schemas:
```yaml
parameters:
  - in: query
    name: filters
    content:
      application/json: # <---- media type indicates how to serialize / deserialize the parameter content
        schema:
          type: object
          properties:
            date_from:
              type: string
              format: date
            date_to:
              type: string
              format: date
```

In the above example, a request example using the parameter above should be something like:
```
# before url encode:
GET example.com/?filters={"date_from":"2026-05-14","date_to":"2026-05-16"}

# after url encode
GET example.com/?filters=%7B%22date_from%22%3A%222026-05-14%22%2C%22date_to%22%3A%222026-05-16%22%7D
```

## Solution

Attempt to read `param[:content][:'application/json'][:schema]` before reading `param[:schema]`. When present, return the serialized param as JSON.

NOTE: this PR only handles query parameters (I guess it's also possible to have JSON-formatted params inside request bodies, but it's even more unusual and out of the scope of this PR)

### This concerns this parts of the OpenAPI Specification:
* https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content
* https://spec.openapis.org/oas/v3.0.4#fixed-fields-for-use-with-content

### The changes I made are compatible with:
- [x] OAS3
- [x] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [x] Added tests
- [x] Changelog updated
- [ ] Added documentation to README.md
- [x] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

_NOTE: didn't add to README as it's a bit of a niche feature (just like we don't mention niche non-default parameter styles such as `pipeDelimited`)_

### Steps to Test or Reproduce

Example of how to describe a JSON-formatted query parameter:
```ruby
      parameter name: 'filters',
                in: :query,
                description: 'JSON-encoded filter object',
                content: {
                  'application/json' => {
                    schema: {
                      type: :object,
                      properties: {
                        date_from: {
                          type: :string,
                          format: 'date',
                          description: 'Filter blogs created from this date',
                        },
                        date_to: {
                          type: :string,
                          format: 'date',
                          description: 'Filter blogs created up to this date',
                        }
                      }
                    }
                  }
                }
```