### PR TITLE
fix: scope response-level `produces` to avoid content type collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Added
 
 - Add support for Ruby 3.4.
+- Support response-level `produces` (allows definition of different schemas per content type)
 
 ## Changed
 

--- a/rswag-specs/lib/rswag/specs/example_group_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_group_helpers.rb
@@ -33,9 +33,20 @@ module Rswag
       end
 
       # These are array properties - note the splat operator
-      %i[tags consumes produces schemes].each do |attr_name|
+      %i[tags consumes schemes].each do |attr_name|
         define_method(attr_name) do |*value|
           metadata[:operation][attr_name] = value
+        end
+      end
+
+      # `produces` can be scoped to a specific response when called inside a `response` block.
+      # In that case, store it on the response metadata rather than the shared operation metadata,
+      # so that different responses can declare different content types.
+      def produces(*value)
+        if metadata.key?(:response)
+          metadata[:response][:produces] = value
+        else
+          metadata[:operation][:produces] = value
         end
       end
 

--- a/rswag-specs/lib/rswag/specs/openapi_formatter.rb
+++ b/rswag-specs/lib/rswag/specs/openapi_formatter.rb
@@ -6,7 +6,7 @@ require 'openapi_helper'
 
 module Rswag
   module Specs
-    class OpenapiFormatter < ::RSpec::Core::Formatters::BaseTextFormatter
+    class OpenapiFormatter < ::RSpec::Core::Formatters::BaseTextFormatter # rubocop:disable Metrics/ClassLength
       ::RSpec::Core::Formatters.register self, :example_group_finished, :stop
 
       def initialize(output, config = Rswag::Specs.config)
@@ -88,11 +88,17 @@ module Rswag
       end
 
       def upgrade_response_produces!(openapi_spec, metadata)
-        # Accept header
-        mime_list = Array(metadata[:operation][:produces] || openapi_spec[:produces])
+        # Response-level `produces` takes precedence over operation-level, allowing different
+        # responses within the same operation to declare distinct content types.
+        mime_list = Array(
+          metadata[:response][:produces] ||
+          metadata[:operation][:produces] ||
+          openapi_spec[:produces]
+        )
         target_node = metadata[:response]
         upgrade_content!(mime_list, target_node)
         metadata[:response].delete(:schema)
+        metadata[:response].delete(:produces)
       end
 
       def upgrade_content!(mime_list, target_node)

--- a/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
+++ b/rswag-specs/spec/rswag/specs/example_group_helpers_spec.rb
@@ -76,6 +76,17 @@ module Rswag
         end
       end
 
+      describe '#produces(value) inside a response block' do
+        before { subject.produces('image/png') }
+
+        let(:api_metadata) { { operation: {}, response: { code: '200', description: 'thumbnail' } } }
+
+        it "adds to the 'response' metadata instead of 'operation'" do
+          expect(api_metadata[:response][:produces]).to eq(['image/png'])
+          expect(api_metadata[:operation][:produces]).to be_nil
+        end
+      end
+
       describe '#parameter(attributes)' do
         context "when called at the 'path' level" do
           before { subject.parameter(name: :blog, in: :body, schema: { type: 'object' }) }

--- a/rswag-specs/spec/rswag/specs/openapi_formatter_spec.rb
+++ b/rswag-specs/spec/rswag/specs/openapi_formatter_spec.rb
@@ -80,6 +80,30 @@ module Rswag
             )
           end
         end
+
+        context 'with response-level produces' do
+          let(:openapi_spec) { { openapi: '3.0' } }
+          let(:document) { nil }
+          let(:response_metadata) do
+            {
+              code: '200',
+              description: 'thumbnail found',
+              produces: ['image/png'],
+              schema: { type: :string, format: :binary }
+            }
+          end
+
+          it 'uses response-level produces to set the content type key' do
+            expect(openapi_spec.dig(:paths, '/blogs', :post, :responses, '200', :content)).to eq(
+              'image/png' => { schema: { type: :string, format: :binary } }
+            )
+          end
+
+          it 'does not include produces or schema directly on the response node' do
+            response_node = openapi_spec.dig(:paths, '/blogs', :post, :responses, '200')
+            expect(response_node.keys).not_to include(:produces, :schema)
+          end
+        end
       end
 
       describe '#stop' do

--- a/test-app/app/controllers/blogs_controller.rb
+++ b/test-app/app/controllers/blogs_controller.rb
@@ -35,6 +35,19 @@ class BlogsController < ApplicationController
     head @blog.save ? :ok : :unprocessable_entity
   end
 
+  def download
+    @blog = Blog.find_by_id(params[:id])
+
+    if @blog.nil?
+      head :not_found
+    elsif @blog.thumbnail.blank?
+      body = { errors: { messages: ['No thumbnail available for selected blog'] } }
+      render json: body, status: :unprocessable_entity
+    else
+      send_file File.join('public/uploads', @blog.thumbnail), filename: @blog.thumbnail, disposition: 'attachment'
+    end
+  end
+
   # GET /blogs
   def index
     @blogs = Blog.all

--- a/test-app/config/routes.rb
+++ b/test-app/config/routes.rb
@@ -5,6 +5,7 @@ TestApp::Application.routes.draw do
   post '/blogs/alternate', to: 'blogs#alternate_create'
   resources :blogs
   put '/blogs/:id/upload', to: 'blogs#upload'
+  get '/blogs/:id/download', to: 'blogs#download'
 
   post 'auth-tests/basic', to: 'auth_tests#basic'
   post 'auth-tests/api-key', to: 'auth_tests#api_key'

--- a/test-app/openapi/v1/openapi.json
+++ b/test-app/openapi/v1/openapi.json
@@ -253,7 +253,7 @@
         "operationId": "getBlog",
         "responses": {
           "200": {
-            "description": "blog found - openapi_no_additional_properties = true",
+            "description": "blog found - tagged :openapi_no_additional_properties",
             "headers": {
               "ETag": {
                 "schema": {
@@ -356,6 +356,47 @@
             }
           },
           "required": true
+        }
+      }
+    },
+    "/blogs/{id}/download": {
+      "get": {
+        "summary": "Downloads a blog thumbnail",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "thumbnail found",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "blog not found"
+          },
+          "422": {
+            "description": "no thumbnail available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors_object"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/test-app/spec/integration/blogs_spec.rb
+++ b/test-app/spec/integration/blogs_spec.rb
@@ -247,4 +247,37 @@ RSpec.describe 'Blogs API', openapi_spec: 'v1/openapi.json', type: :request do
       end
     end
   end
+
+  path '/blogs/{id}/download' do
+    get 'Downloads a blog thumbnail' do
+      parameter name: 'id', in: :path, schema: { type: :string }
+
+      let(:blog) { Blog.create(title: 'foo', content: 'bar', thumbnail: 'thumbnail.png') }
+      let(:request_params) { { 'id' => blog.id } }
+
+      response '200', 'thumbnail found' do
+        produces 'image/png'
+        schema type: :string, format: :binary
+
+        it 'returns the thumbnail file' do |example|
+          submit_request(example.metadata)
+          expect(response.headers['Content-Type']).to eq('image/png')
+          expect(response.body).not_to be_empty
+        end
+      end
+
+      response '404', 'blog not found' do
+        let(:request_params) { { 'id' => 'invalid' } }
+        run_test!
+      end
+
+      response '422', 'no thumbnail available' do
+        produces 'application/json'
+        schema '$ref' => '#/components/schemas/errors_object'
+        let(:blog) { Blog.create(title: 'foo', content: 'bar') }
+
+        run_test!
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

When an operation has multiple responses with different content types, calling `produces` inside each `response` block causes the last value to overwrite all earlier ones in the generated spec. This happens because all sibling `response` blocks share the same `metadata[:operation]` hash reference, so any write to `metadata[:operation][:produces]` is visible to every other response.

See #884 for a full reproduction case.

## Solution
`produces` is given its own method in `ExampleGroupHelpers`. When called inside a `response` block (detected via `metadata.key?(:response)`), it stores the value on `metadata[:response][:produces]` rather than on the shared `metadata[:operation]` hash, scoping the content type to that specific response without affecting siblings.

`OpenapiFormatter#upgrade_response_produces!` is updated to look up `produces` at the response level first, falling back to operation level, then spec level, and cleans up the transient `:produces` key from the response node after use.

Operation-level `produces` (called outside any `response` block) continues to work exactly as before.

### This concerns this parts of the OpenAPI Specification:
* [Response Object – `content`](https://spec.openapis.org/oas/v3.1.0#response-object)
* [Media Type Object](https://spec.openapis.org/oas/v3.1.0#media-type-object)

### The changes I made are compatible with:
- [x] OAS3
- [x] OAS3.1

### Related Issues
Fixes #884

### Checklist
- [x] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
1. `cd test-app && bundle exec rake rswag` — inspect `openapi/v1/openapi.json` and verify that `GET /blogs/{id}/download` → `200` is keyed under `image/png` and `422` is keyed under `application/json`.
2. `cd rswag-specs && bundle exec rspec` — all examples should pass.